### PR TITLE
Add missing `k0rdent.mirantis.com/component` label in quickstart

### DIFF
--- a/docs/quickstart-2-aws.md
+++ b/docs/quickstart-2-aws.md
@@ -192,6 +192,8 @@ kind: Secret
 metadata:
   name: aws-cluster-identity-secret
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
 type: Opaque
 stringData:
   AccessKeyID: "EXAMPLE_ACCESS_KEY_ID"
@@ -217,6 +219,8 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterStaticIdentity
 metadata:
   name: aws-cluster-identity
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
 spec:
   secretRef: aws-cluster-identity-secret
   allowedNamespaces:

--- a/docs/quickstart-2-azure.md
+++ b/docs/quickstart-2-azure.md
@@ -108,6 +108,8 @@ kind: Secret
 metadata:
   name: azure-cluster-identity-secret
   namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
 stringData:
   clientSecret: SP_PASSWORD_SP_PASSWORD # Password retrieved from the Service Principal
 type: Opaque
@@ -129,10 +131,11 @@ Create a YAML file called `azure-cluster-identity.yaml`. Make sure that `.spec.c
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity
 metadata:
-  labels:
-    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: azure-cluster-identity
   namespace: kcm-system
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+    k0rdent.mirantis.com/component: "kcm"
 spec:
   allowedNamespaces: {}
   clientID: SP_APP_ID_SP_APP_ID # The App ID retrieved from the Service Principal above in Step 2


### PR DESCRIPTION
Adding this label manually to selected objects is needed to support backup feature (Velero) together with pluggable providers feature.
