### PR TITLE
Updates to admin guide - part 1

### DIFF
--- a/docs/admin-before.md
+++ b/docs/admin-before.md
@@ -52,9 +52,9 @@ their applications. The administrator simply updates the `Credential` object and
 
 You can find more information on creating these `Credential`s in [the Credentials chapter](admin-credentials.md).
 
-## k0rdent vs GitOps
+## k0rdent and GitOps
 
-At its heart, k0rdent is a way to declaratively specify what should be happening in the infrastructure and
+At its heart, k0rdent is a Kubernetes-native way to declaratively specify what should be happening in the infrastructure and
 have that maintained. In other words, if you want to, say, scale up a cluster, you would give that cluster a new
 definition that includes the additional nodes, and then k0rdent, seeing that reality doesn't match that definition, 
 will make it happen.

--- a/docs/admin-before.md
+++ b/docs/admin-before.md
@@ -20,7 +20,7 @@ Together, KCM and KSM interoperate to manifest a complete, template-driven syste
 the cluster, such as where to find images, and so on. These templates get installed into k0rdent, but they don't do 
 anything until you reference them in a `ClusterDeployment` that represents an actual cluster.
 
-![The Basic Architecture](./assets/k0rdent-basics-2.svg)
+![The Basic Architecture](./assets/k0rdent-basics-1.svg)
 
 k0rdent can also manage these clusters, upgrading, scaling them, or installing software and services.
 
@@ -29,7 +29,7 @@ you also use templates. These `ServiceTemplate`s are like `ClusterTemplate`s, in
 they're actually referenced, they don't do anything. When you reference a `ServiceTemplate` as part of a `ClusterDeployment`,
 k0rdent knows to install that service into that cluster.
 
-![Adding an application](./assets/k0rdent-basics-1.svg)
+![Adding an application](./assets/k0rdent-basics-2.svg)
 
 These services can be actual services, such as Nginx or Kyverno, or they can be user applications.
 

--- a/docs/admin-installation.md
+++ b/docs/admin-installation.md
@@ -24,7 +24,7 @@ k0rdent management clusters can also be mixed-use. For example, a cloud Kubernet
 
 ### Where k0rdent management clusters can live
 
-k0rdent management clusters can live anywhere, so long as they are connected via internet to the clusters they manage. Unlike prior generations of Kubernetes cluster managers, there's no technical need to co-locate a k0rdent manager with managed clusters on a single infrastructure. In fact, k0rdent is being built to manage multiple IDPs and platforms, providing a single point of control and visibility. Deciding where to put a management cluster (or multiple clusters) is best done by assessing the requirements of your use case. Considered in the abstract, a k0rdent management cluster should be:
+k0rdent management clusters can live anywhere. Unlike prior generations of Kubernetes cluster managers, there's no technical need to co-locate a k0rdent manager with managed clusters on a single infrastructure. k0rdent provides a single point of control and visibility across any cloud, any infrastructure, anywhere, on-premise or off. Deciding where to put a management cluster (or multiple clusters) is best done by assessing the requirements of your use case. Considered in the abstract, a k0rdent management cluster should be:
 
 * Resilient and available
 * Accessible and secure
@@ -34,25 +34,22 @@ k0rdent management clusters can live anywhere, so long as they are connected via
 * Monitored and observable
 * Equipped for backup and disaster recovery
 
-And of course, where can these requirements be procured at reasonable cost? In many cases the simplest and most cost-effective way to run these clusters is on a provider such as Amazon Elastic Kubernetes Service or Azure Kubernetes Service, where many of these functions are handled for you.
+### Minimum requirements for single-node k0rdent management clusters for testing
 
-### Minimum requirements
-
-There isn't a strict minimum system requirement for k0rdent, but the following are recommended:
+There isn't a strict minimum system requirement for k0rdent, but the following are recommended for a single node:
 
 * A minimum of 32GB RAM
 * 8 cores
 * 100GB SSD
 
-### Recommended requirements for production
+This configuration is only sufficient for the base case.  If you will run k0rdent Observability and FinOps (KOF) you will need significantly more resources and in particular, much more storage.
 
-Of course, if you are running in production you will want a scale-out architecture and will to scale your k0rdent cluster horizontally; however, there will be a tradeoff in terms of individual node performance.  You will have to determine a good tradeoff point.
+### Recommended requirements for single-node k0rdent management clusters for production
 
-A rough guide is for large scale deployments, per node system requirements should be:
+We do not recommend running k0rdent in production on a single node.  If you are running in production you will want a scale-out architecture.  These documents do not currently cover this case.
 
-* 64GB RAM
-* 16 cores
-* 200GB SSD
+> IMPORTANT:
+> Detailed instructions for deploying k0rdent management clusers into a multi-node configuration and scaling them as needed are COMING SOON!
 
 ### Create and prepare a Kubernetes cluster with k0s
 

--- a/docs/admin-installation.md
+++ b/docs/admin-installation.md
@@ -38,11 +38,21 @@ And of course, where can these requirements be procured at reasonable cost? In m
 
 ### Minimum requirements
 
-[[[ TODO ]]]
+There isn't a strict minimum system requirement for k0rdent, but the following are recommended:
+
+* A minimum of 32GB RAM
+* 8 cores
+* 100GB SSD
 
 ### Recommended requirements for production
 
-[[[ TODO ]]]
+Of course, if you are running in production you will want a scale-out architecture and will to scale your k0rdent cluster horizontally; however, there will be a tradeoff in terms of individual node performance.  You will have to determine a good tradeoff point.
+
+A rough guide is for large scale deployments, per node system requirements should be:
+
+* 64GB RAM
+* 16 cores
+* 200GB SSD
 
 ### Create and prepare a Kubernetes cluster with k0s
 
@@ -132,11 +142,11 @@ helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.1.0 -n kcm-sys
 ```console
 WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: ./KUBECONFIG
 WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: ./KUBECONFIG
-Pulled: ghcr.io/mirantis/hmc/charts/hmc:0.0.3
+Pulled: ghcr.io/k0rdent/kcm/charts/kcm:0.1.0
 Digest: sha256:1f75e8e55c44d10381d7b539454c63b751f9a2ec6c663e2ab118d34c5a21087f
-NAME: hmc
+NAME: kcm
 LAST DEPLOYED: Mon Dec  9 00:32:14 2024
-NAMESPACE: hmc-system
+NAMESPACE: kcm-system
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None

--- a/docs/admin-prepare.md
+++ b/docs/admin-prepare.md
@@ -15,7 +15,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 
     Follow the instructions in [Install k0rdent](admin-installation.md) to create a management cluster with k0rdent running.
 
-1. Install `clusterawsadm`
+2. Install `clusterawsadm`
 
     k0rdent uses the Cluster API (CAPI) to marshal clouds and infrastructures. For AWS, this means using the components from the Cluster API Provider AWS (CAPA) project. clusterawsadm, a CLI tool created by CAPA project, helps with AWS-specific tasks such as creating IAM roles and policies, as well as credential configuration. To install clusterawsadm on Ubuntu on x86 hardware, execute these commands:
 
@@ -24,7 +24,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
     sudo install -o root -g root -m 0755 clusterawsadm-linux-amd64 /usr/local/bin/clusterawsadm
     ```
 
-2. Configure AWS IAM
+3. Configure AWS IAM
 
     Next you'll need to create the IAM policies and service account k0rdent will use to take action within the AWS infrastructure. (Note that you only need to do this once.)
 
@@ -37,7 +37,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
     export AWS_SESSION_TOKEN=<YOUR_SESSION_TOKEN> # Optional. If you are using Multi-Factor Auth.
     ```
 
-3. Create the IAM CloudFormation 
+4. Create the IAM CloudFormation stack
 
 	Now use `clusterawsadm` to create the IAM CloudFormation stack:
 
@@ -45,7 +45,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 	clusterawsadm bootstrap iam create-cloudformation-stack
 	```
 	
-4. Install the AWS CLI
+5. Install the AWS CLI
  
 	With the stack in place you can create the AWS IAM user. You can do this in the UI, but it's also possible to do it from the command line using the aws CLI tool.  Start by installing it, if you haven't already:
 
@@ -58,7 +58,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 
 	The tool recognizes the environment variables you created earlier, so there's no need to login.
 
-5. Create the IAM user. 
+6. Create the IAM user. 
 
 	The actual `user-name` parameter is arbitrary; you can specify it as anything you like:
 
@@ -77,7 +77,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 	}
 	```
 
-6. Assign the relevant policies
+7. Assign the relevant policies
  
 	You'll need to assign the following policies to the user you just created:
 
@@ -196,7 +196,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 	kubectl apply -f aws-cluster-identity-secret.yaml -n kcm-system
 	```
 
-11. Create the `AWSClusterStaticIdentity`
+10. Create the `AWSClusterStaticIdentity`
 
 	Create the `AWSClusterStaticIdentity` object in a file named `aws-cluster-identity.yaml`:
 
@@ -219,7 +219,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 	kubectl apply -f aws-cluster-identity.yaml  -n kcm-system
 	```
 
-12. Create the `Credential`
+11. Create the `Credential`
 
 	Finally, create the kcm `Credential` object, making sure to reference the `AWSClusterStaticIdentity` you just created:
 
@@ -242,7 +242,7 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
 	kubectl apply -f aws-cluster-identity-cred.yaml -n kcm-system
 	```
 
-13. Deploy a cluster
+12. Deploy a cluster
 
 	Make sure everything is configured properly by creating a `ClusterDeployment`. Start with a YAML file specifying the `ClusterDeployment`, as in:
 
@@ -264,14 +264,15 @@ k0rdent is able to deploy managed clusters as both EC2-based Kubernetes clusters
         instanceType: t3.small
 	```
 
-	A couple of things to notice:
-	- You're giving it an arbitrary name in `.metadata.name` (`my-aws-clusterdeployment1`)
-	- You're referencing the credential you created in the previous step, `aws-cluster-identity-cred`. This enables you to set up a system where users can take advantage of having access to the credentials to the AWS account without actually having those credentials in hand.
-	- You need to choose a template to use for the cluster, in this case `aws-standalone-cp-0-0-5`. You can get a list of available templates using:
-	
-    ```shell
-	kubectl get clustertemplate -n kcm-system
-	```
+  > NOTE:
+  > - You're giving it an arbitrary name in `.metadata.name` (`my-aws-clusterdeployment1`)
+  > - You're referencing the credential you created in the previous step, `aws-cluster-identity-cred`. This enables you to set up a system where users can take advantage of having access to the credentials to the AWS account without actually having those credentials in hand.
+  > - You need to choose a template to use for the cluster, in this case `aws-standalone-cp-0-0-5`. You can get a list of available templates using:
+
+  ```shell
+  kubectl get clustertemplate -n kcm-system
+  ```
+
 	```console
 	NAMESPACE    NAME                            VALID
 	kcm-system   adopted-cluster-0-0-2           true
@@ -351,11 +352,13 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     In order for k0rdent to deploy and manage clusters, it needs to be able to work with Azure resources such as 
     compute, network, and identity. Make sure the subscription you're using has the following resource providers registered:
 
-    - `Microsoft.Compute`
-    - `Microsoft.Network`
-    - `Microsoft.ContainerService`
-    - `Microsoft.ManagedIdentity`
-    - `Microsoft.Authorization`
+    ```shell
+    Microsoft.Compute
+    Microsoft.Network
+    Microsoft.ContainerService
+    Microsoft.ManagedIdentity
+    Microsoft.Authorization
+    ```
 
     To register these providers, run the following commands in the Azure CLI:
 
@@ -611,15 +614,17 @@ k0rdent is able to deploy managed clusters on OpenStack virtual machines. Follow
 
     This credential should include:
 
-    - `OS_AUTH_URL`
-    - `OS_APPLICATION_CREDENTIAL_ID`
-    - `OS_APPLICATION_CREDENTIAL_SECRET`
-    - `OS_REGION_NAME`
-    - `OS_INTERFACE`
-    - `OS_IDENTITY_API_VERSION` (commonly `3`)
-    - `OS_AUTH_TYPE` (e.g., `v3applicationcredential`)
+    ```shell
+    OS_AUTH_URL
+    OS_APPLICATION_CREDENTIAL_ID
+    OS_APPLICATION_CREDENTIAL_SECRET
+    OS_REGION_NAME
+    OS_INTERFACE
+    OS_IDENTITY_API_VERSION
+    OS_AUTH_TYPE (e.g. v3applicationcredential)
+    ```
 
-    While it's possible to use a username and password instead of the Application Credential--adjust your YAML accordingly--an 
+    While it's possible to use a username and password instead of the Application Credential &mdash; adjust your YAML accordingly &mdash; an 
     Application Credential is strongly recommended because it limits scope and improves security over a raw username/password approach.
 
 4. Create the OpenStack Credentials Secret
@@ -787,9 +792,11 @@ To enable users to deploy managed clusers on vSphere, follow these steps:
     to manipulate vSphere resources. The user should have the following 
     required privileges:
 
-    - `Virtual machine`: Full permissions are required
-    - `Network`: `Assign network` is sufficient
-    - `Datastore`: The user should be able to manipulate virtual machine files and metadata
+    ```shell
+    Virtual machine: Full permissions are required
+    Network: Assign network is sufficient
+    Datastore: The user should be able to manipulate virtual machine files and metadata
+    ```
 
     In addition to that, specific CSI driver permissions are required. See
     [the official doc](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-0AB6E692-AA47-4B6A-8CEA-38B754E16567.html)
@@ -819,7 +826,9 @@ To enable users to deploy managed clusers on vSphere, follow these steps:
     `172.16.0.0/24` should have a DHCP range of `172.16.0.100-172.16.0.254` only) so that LoadBalancer services will not create any IP conflicts in the
     network.
 
-6. To enable k0rdent to access vSphere resources, create the appropriate credentials objects. For a full explanation of how Credentials work, see the [main Credentials chapter](admin-credentials.md) but for now, follow these steps:
+6. vSphere Credentials
+
+    To enable k0rdent to access vSphere resources, create the appropriate credentials objects. For a full explanation of how Credentials work, see the [main Credentials chapter](admin-credentials.md) but for now, follow these steps:
 
     Create a `Secret` Object with the username and password
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,9 +110,6 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-  - mdx_truly_sane_lists: # https://github.com/mkdocs/mkdocs/issues/545#issuecomment-522196661
-      nested_indent: 2
-      truly_sane: true
   - toc:
       permalink: "#"
       toc_depth: 3


### PR DESCRIPTION
    docs: Update admin documentation with content and formatting improvements
    
    - Add system requirements for both minimal and production setups
    - Fix numbered list continuity in admin-prepare.md
    - Update 'k0rdent vs GitOps' section title and clarify description
    - Replace placeholder TODO sections with actual content
    - Improve formatting of command snippets and shell examples
    - Replace HMC references with KCM in installation docs
    - Enhance readability of Azure, OpenStack, and vSphere credentials sections
    - flipped the templates diagrams around so they are in the proper order