### PR TITLE
Fix the child clusters' KUBECONFIGs invocation in the Quickstarts

### DIFF
--- a/docs/quickstart-2-aws.md
+++ b/docs/quickstart-2-aws.md
@@ -383,8 +383,7 @@ kubectl -n kcm-system get secret my-aws-clusterdeployment1-kubeconfig -o jsonpat
 And you can use the `kubeconfig` to see what's running on the cluster:
 
 ```shell
-KUBECONFIG="my-aws-clusterdeployment1-kubeconfig.kubeconfig"
-kubectl get pods -A
+KUBECONFIG="my-aws-clusterdeployment1-kubeconfig.kubeconfig" kubectl get pods -A
 ```
 
 ## List child clusters

--- a/docs/quickstart-2-azure.md
+++ b/docs/quickstart-2-azure.md
@@ -368,8 +368,7 @@ kubectl -n kcm-system get secret my-azure-clusterdeployment1-kubeconfig -o jsonp
 And you can use the kubeconfig to see what's running on the cluster:
 
 ```shell
-KUBECONFIG="my-azure-clusterdeployment1-kubeconfig.kubeconfig"
-kubectl get pods -A
+KUBECONFIG="my-azure-clusterdeployment1-kubeconfig.kubeconfig" kubectl get pods -A
 ```
 
 ## List child clusters


### PR DESCRIPTION
If we use a separate command to set up KUBECONFIG then it re-defines our current KUBECONFIG (i.e. the management cluster ones) for the whole shell session and the next quickstarts' kubectl commands don't work.