### PR TITLE
Correct pod count in kcm-system namespace from 15 to 17

### DIFF
--- a/docs/admin-installation.md
+++ b/docs/admin-installation.md
@@ -85,7 +85,7 @@ The helm chart deploys the KCM operator and prepares the environment, and KCM th
 
 ## Confirming the deployment
 
-To understand whether installation is complete, start by making sure all pods are ready in the `kcm-system` namespace. There should be 15:
+To understand whether installation is complete, start by making sure all pods are ready in the `kcm-system` namespace. There should be 17:
 
 ```shell
 kubectl get pods -n kcm-system


### PR DESCRIPTION
Updated the expected number of k0rdent pods in `kcm-system` namespace to 17.  Currently docs says 15. 

**Fresh installation:**
```
❯ kubectl get pods -n kcm-system --no-headers | wc -l
      17
```

This ensures accuracy in installation verification steps.  