### PR TITLE
Update AWSClusterStaticIdentity object with API and formatting updates

### DIFF
--- a/docs/admin-credentials.md
+++ b/docs/admin-credentials.md
@@ -26,6 +26,7 @@ In order to pass credentials to k0rdent so it can take action, the following has
 2. A provider-specific `ClusterIdentity` gets created. The `ClusterIdentity` references the `Secret` from step one. For example, for an AWS cluster, this object might look like this:
 
     ```yaml
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSClusterStaticIdentity
     metadata:
       name: aws-cluster-identity

--- a/docs/admin-credentials.md
+++ b/docs/admin-credentials.md
@@ -48,7 +48,7 @@ In order to pass credentials to k0rdent so it can take action, the following has
       name: aws-cluster-credential
       namespace: kcm-system
     spec:
-        description: "Credential Example"
+      description: "Credential Example"
       identityRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSClusterStaticIdentity

--- a/docs/admin-credentials.md
+++ b/docs/admin-credentials.md
@@ -34,7 +34,7 @@ In order to pass credentials to k0rdent so it can take action, the following has
       secretRef: aws-cluster-identity-secret
       allowedNamespaces:
         selector:
-        matchLabels: {}
+          matchLabels: {}
     ```
 
     Notice that it references the `aws-cluster-identity-secret` we created earlier. It also specifies the namespaces in which this `ClusterIdentity` can be used. (In this case there are no restrictions.)

--- a/docs/admin-prepare.md
+++ b/docs/admin-prepare.md
@@ -200,7 +200,8 @@ k0rdent can deploy managed clusters as both EC2-based Kubernetes clusters and EK
 
     Create the `AWSClusterStaticIdentity` object in a file named `aws-cluster-identity.yaml`:
 
-    ```shell
+    ```yaml
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSClusterStaticIdentity
     metadata:
       name: aws-cluster-identity

--- a/docs/admin-prepare.md
+++ b/docs/admin-prepare.md
@@ -231,11 +231,11 @@ k0rdent can deploy managed clusters as both EC2-based Kubernetes clusters and EK
       name: aws-cluster-identity-cred
       namespace: kcm-system
     spec:
-    description: "Credential Example"
-    identityRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: AWSClusterStaticIdentity
-      name: aws-cluster-identity
+      description: "Credential Example"
+      identityRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSClusterStaticIdentity
+        name: aws-cluster-identity
     ```
     Apply the YAML to your cluster, again keeping it in the `kcm-system` namespace:
 

--- a/docs/admin-prepare.md
+++ b/docs/admin-prepare.md
@@ -209,7 +209,7 @@ k0rdent can deploy managed clusters as both EC2-based Kubernetes clusters and EK
       secretRef: aws-cluster-identity-secret
       allowedNamespaces:
         selector:
-        matchLabels: {}
+          matchLabels: {}
     ```
 
     Notice that the `secretRef` references the `Secret` you created in the previous step.

--- a/docs/user-create-cluster.md
+++ b/docs/user-create-cluster.md
@@ -34,7 +34,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
       name: accounting-cluster-credential
       namespace: accounting
     spec:
-        description: "Credentials for Accounting AWS account"
+      description: "Credentials for Accounting AWS account"
       identityRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSClusterStaticIdentity


### PR DESCRIPTION
Currently, the API for `AWSClusterStaticIdentity` is not set in the sample yaml file in the docs. I have updated it with the API version and applied YAML formatting for better readability.