### PR TITLE
Create the default storage class for Azure managed clusters

### DIFF
--- a/docs/quickstart-2-azure.md
+++ b/docs/quickstart-2-azure.md
@@ -305,6 +305,19 @@ data:
     type: Opaque
     data:
       cloud-config: {{ $cloudConfig | toJson | b64enc }}
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: managed-csi
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: disk.csi.azure.com
+    parameters:
+      skuName: StandardSSD_LRS
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true
 ```
 
 Object name needs to be exactly `azure-cluster-identity-resource-template.yaml`, `AzureClusterIdentity` object name + `-resource-template` string suffix.


### PR DESCRIPTION
As for now we can't deploy any workload requiring persistent storage on Azure-based managed clusters without additional configuration.
This PR adds creation of the default storage class for Azure-based managed clusters.
The config is ported from - https://github.com/k0rdent/catalog/blob/main/charts/utils/azure-credential/templates/resource-template.yaml