### PR TITLE
Add documentation draft about the 0.2.0 upgrade process specifics

### DIFF
--- a/docs/admin/upgrade/admin-upgrading-k0rdent.md
+++ b/docs/admin/upgrade/admin-upgrading-k0rdent.md
@@ -1,5 +1,8 @@
 # Upgrading {{{ docsVersionInfo.k0rdentName }}}
 
+IMPORTANT: When upgrading to K0rdent `0.2.0` follow this [instruction](upgrade-to-0-2-0.md) and perform
+additional manual steps.
+
 Upgrading {{{ docsVersionInfo.k0rdentName }}} involves making upgrades to the `Management` object. To do that, you must have the `Global Admin` role. (For detailed information about {{{ docsVersionInfo.k0rdentName }}} RBAC roles and permissions, refer to the [RBAC documentation](../access/rbac/index.md).) Follow these steps to upgrade {{{ docsVersionInfo.k0rdentName }}}:
 
 1. Create a new `Release` object

--- a/docs/admin/upgrade/upgrade-to-0-2-0.md
+++ b/docs/admin/upgrade/upgrade-to-0-2-0.md
@@ -1,0 +1,70 @@
+# Upgrading to K0rdent 0.2.0
+
+In K0rdent `0.2.0`, the `k0smotron` management component has been renamed to
+`cluster-api-provider-k0sproject-k0smotron`. To safely upgrade from `0.1.0` to `0.2.0`, follow the upgrade guide
+and perform the additional manual steps outlined below:
+
+1. Follow [Upgrading guide](admin-upgrading-k0rdent.md) and create a new Release object (steps 1-2)
+
+2. Verify the new Release status
+
+   Wait for the new Release to have `status.ready: true`. You can monitor it in a lifetime using this command:
+
+    ```shell
+    kubectl get release kcm-0-2-0 -o=jsonpath={.status.ready}
+    ```
+
+    An example of the succeeded response:
+    ```console
+    true
+    ```
+
+4. Manually delete the `k0smotron` providers (replace `kcm-system` with your system namespace):
+
+   ```shell
+   kubectl -n kcm-system delete infrastructureproviders.operator.cluster.x-k8s.io k0sproject-k0smotron
+   kubectl -n kcm-system delete controlplaneproviders.operator.cluster.x-k8s.io k0sproject-k0smotron
+   kubectl -n kcm-system delete bootstrapproviders.operator.cluster.x-k8s.io k0sproject-k0smotron
+   ```
+
+5. Instead of the step 3 from [Upgrading guide](admin-upgrading-k0rdent.md) you need to perform an edit
+   of the `Management` object. Run:
+
+   ```shell
+   kubectl edit managements.k0rdent.mirantis.com kcm
+   ```
+
+   And do the following:
+
+   * Set `spec.release` to `kcm-0-2-0`
+   * In `spec.providers` rename the `k0smotron` provider to `cluster-api-provider-k0sproject-k0smotron`:
+
+   ```shell
+   providers:
+   - name: cluster-api-provider-k0sproject-k0smotron
+   ```
+
+   The full example of the new Management spec:
+
+   ```yaml
+   apiVersion: k0rdent.mirantis.com/v1alpha1
+   kind: Management
+   metadata:
+     labels:
+       k0rdent.mirantis.com/component: kcm
+     name: kcm
+   spec:
+     core:
+       capi: {}
+       kcm: {}
+     providers:
+     - name: cluster-api-provider-k0sproject-k0smotron
+     - name: projectsveltos
+     - name: cluster-api-provider-aws
+     - name: cluster-api-provider-azure
+     - name: cluster-api-provider-openstack
+     - name: cluster-api-provider-vsphere
+     release: kcm-0-2-0
+   ```
+
+6. Follow [Upgrading guide](admin-upgrading-k0rdent.md) and verify the upgrade (step 4)


### PR DESCRIPTION
This PR contains the instruction on how to upgrade K0rdent to 0.2.0 taking into account the k0smotron management component rename: https://github.com/k0rdent/kcm/pull/1246 and wait for the release readiness since due to https://github.com/k0rdent/kcm/issues/1279 it may take some time.