### PR TITLE
Fix Dockerfile to include actual docs to serve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy MkDocs files
 COPY mkdocs.yml .
 
+# Copy in docs
+COPY docs docs
+
 # Expose the MkDocs server port
 EXPOSE 8000


### PR DESCRIPTION
Right now if you try to build the docker container and serve it will fail due to not having any content. This pull request copies the documentation into the container to serve the content.

```
docker build . --tag k0rdent-docs
docker run --name k0rdent-docs -d --rm -p 8000:8000 k0rdent-docs
```