### PR TITLE
Add managementClusterName to the hosted AWS template

### DIFF
--- a/docs/admin/hosted-control-plane/hcp-aws.md
+++ b/docs/admin/hosted-control-plane/hcp-aws.md
@@ -67,6 +67,7 @@ Follow these steps to set up a k0smotron-hosted control plane on AWS:
       template: aws-hosted-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsHostedCpCluster }}}
       credential: aws-credential
       config:
+        managementClusterName: aws
         clusterLabels: {}
         vpcID: vpc-0a000000000000000
         region: us-west-1
@@ -102,6 +103,7 @@ Follow these steps to set up a k0smotron-hosted control plane on AWS:
       template: aws-hosted-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsHostedCpCluster }}}
       credential: aws-credential
       config:
+        managementClusterName: "{{.metadata.name}}"
         clusterLabels: {}
         vpcID: "{{.spec.network.vpc.id}}"
         region: "{{.spec.region}}"


### PR DESCRIPTION
This PR adds the `managementClusterName` field to the hosted AWS cluster deployment example. Without it, the deployment will fail on validation since `managementClusterName` field is required.