### PR TITLE
Update OpenStack Template Reference

### DIFF
--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -16,9 +16,23 @@ To deploy an OpenStack cluster, the following are the primary parameters in the 
 
 ### SSH Configuration
 
-`sshPublicKey` is the reference name for an existing SSH key configured in OpenStack.
+To access deployed machines over ssh requires two things:
 
-- **ClusterDeployment**: Specify the SSH public key using the `.spec.config.controlPlane.sshPublicKey` and `.spec.config.worker.sshPublicKey` parameters (for the standlone control plane).
+- `sshKeyName` - the reference name for an existing SSH key configured in OpenStack.
+- `bastion` - bastion host being enabled and its flavor and image specified.
+
+#### SSH keys
+
+Specify the SSH public key using the `.spec.config.controlPlane.sshKeyName` and `.spec.config.worker.sshKeyName` parameters (for the standalone control plane).
+
+#### Bastion
+
+Specify `.spec.config.bastion.enabled` to enable it as well as provide `sshKeyName`, `flavor` and `image` in `.spec.config.bastion.spec`, similarly to workers and control plane.
+
+
+Example `ClusterDeployment with enabled bastion can be found [below](#example-clusterdeployment).
+
+
 
 ### Machine Configuration
 
@@ -28,7 +42,7 @@ Configurations for control plane and worker nodes are specified separately under
 |--------------------------------|-----------------------|-----------------------------------------|
 | `flavor`                       | `m1.medium`           | OpenStack flavor for the instance.      |
 | `image.filter.name`            | `ubuntu-22.04-x86_64` | Name of the image.                      |
-| `sshPublicKey`                 | `ramesses-pk`         | Reference name for an existing SSH key. |
+| `sshKeyName`                   | `ramesses-pk`         | Reference name for an existing SSH key. |
 | `securityGroups[].filter.name` | `default`             | Security group for the instance.        |
 
 > NOTE:
@@ -59,19 +73,26 @@ spec:
   template: openstack-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.openstackStandaloneCpCluster }}}
   credential: openstack-cluster-identity-cred
   config:
-    clusterLabels: {}
     clusterLabels:
       k0rdent: demo
     controlPlaneNumber: 1
     workersNumber: 1
+    bastion:
+      enabled: true
+      spec:
+        sshKeyName: my-public-key
+        flavor: m1.small
+        image:
+          filter:
+            name: ubuntu-22.04-x86_64
     controlPlane:
-      sshPublicKey: my-public-key
+      sshKeyName: bastion-public-key
       flavor: m1.medium
       image:
         filter:
           name: ubuntu-22.04-x86_64
     worker:
-      sshPublicKey: my-public-key
+      sshKeyName: bastion-public-key
       flavor: m1.medium
       image:
         filter:
@@ -85,4 +106,3 @@ spec:
       cloudName: openstack
       region: RegionOne
 ```
-

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -4,47 +4,15 @@
 
 To deploy an OpenStack cluster, the following are the primary parameters in the `ClusterDeployment` resource:
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Example</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>.spec.credential</td>
-      <td><code>openstack-cluster-identity-cred</code></td>
-      <td>Reference to the Credential object.</td>
-    </tr>
-    <tr>
-      <td>.spec.template</td>
-      <td><code>openstack-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.openstackStandaloneCpCluster }}}</code></td>
-      <td>Reference to the ClusterTemplate.</td>
-    </tr>
-    <tr>
-      <td>.spec.config.authURL</td>
-      <td><code>https://keystone.yourorg.net/</code></td>
-      <td>Keystone authentication endpoint for OpenStack.</td>
-    </tr>
-    <tr>
-      <td>.spec.config.controlPlaneNumber</td>
-      <td><code>3</code></td>
-      <td>Number of control plane nodes.</td>
-    </tr>
-    <tr>
-      <td>.spec.config.workersNumber</td>
-      <td><code>2</code></td>
-      <td>Number of worker nodes.</td>
-    </tr>
-    <tr>
-      <td>.spec.config.clusterLabels<br>(optional)</td>
-      <td><code>k0rdent: demo</code></td>
-      <td>Labels to apply to the cluster. Used by <br>MultiClusterService.</td>
-    </tr>
-  </tbody>
-</table>
+
+| Parameter                         | Example                               | Description                                                 |
+|-----------------------------------|---------------------------------------|-------------------------------------------------------------|
+| `.spec.credential`                | `openstack-cluster-identity-cred`     | Reference to the `Credential` object.                       |
+| `.spec.template`                  | `openstack-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.openstackStandaloneCpCluster }}}` | Reference to the `ClusterTemplate`. |
+| `.spec.config.authURL`            | `https://keystone.yourorg.net/`       | Keystone authentication endpoint for OpenStack.             |
+| `.spec.config.controlPlaneNumber` | `3`                                   | Number of control plane nodes.                              |
+| `.spec.config.workersNumber`      | `2`                                   | Number of worker nodes.                                     |
+| `.spec.config.clusterLabels`      | `k0rdent: demo`                       | Labels to apply to the cluster. Used by MultiClusterService.|
 
 ### SSH Configuration
 

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -24,12 +24,12 @@ To deploy an OpenStack cluster, the following are the primary parameters in the 
 
 Configurations for control plane and worker nodes are specified separately under `.spec.config.controlPlane` and `.spec.config.worker`:
 
-| Parameter                  | Example                | Description                        |
-|----------------------------|------------------------|------------------------------------|
-| `flavor`                   | `m1.medium`           | OpenStack flavor for the instance.|
-| `image.filter.name`        | `ubuntu-22.04-x86_64` | Name of the image.                |
-| `sshPublicKey`             | `ramesses-pk`         | Reference name for an existing SSH key.|
-| `securityGroups.filter.name`| `default`             | Security group for the instance.  |
+| Parameter                      | Example               | Description                             |
+|--------------------------------|-----------------------|-----------------------------------------|
+| `flavor`                       | `m1.medium`           | OpenStack flavor for the instance.      |
+| `image.filter.name`            | `ubuntu-22.04-x86_64` | Name of the image.                      |
+| `sshPublicKey`                 | `ramesses-pk`         | Reference name for an existing SSH key. |
+| `securityGroups[].filter.name` | `default`             | Security group for the instance.        |
 
 > NOTE:
 > Make sure `.spec.credential` references the `Credential` object.

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -35,6 +35,18 @@ Configurations for control plane and worker nodes are specified separately under
 > Make sure `.spec.credential` references the `Credential` object.
 > The recommended minimum vCPU value for the control plane flavor is 2, while for the worker node flavor, it is 1. For detailed information, refer to the [machine-flavor CAPI docs](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/docs/book/src/clusteropenstack/configuration.md#machine-flavor).
 
+### External Network Configuration
+
+If your OpenStack cloud contains more than one network marked as external it is necessary to provide which one clusterapi should use when creating a cluster. You do this by providing `.spec.config.externlNetwork.filter.name` value with the name of your external network.
+
+### Load Balancer Configuration
+
+If your user doesn't have access to or your cloud doesn't utilize octavia load balancer it is possible to disable usage of it by specifying
+`.spec.config.apiServerLoadBalancer.enabled` as `false`.
+
+> WARNING: Disabling loadbalancer blocks usage of `LoadBalancer` type services in cluster until one is manually installed.
+
+
 ### Example ClusterDeployment
 
 ```yaml
@@ -64,9 +76,13 @@ spec:
       image:
         filter:
           name: ubuntu-22.04-x86_64
+    externalNetwork:
+      filter:
+        name: "public"
     authURL: https://my-keystone-openstack-url.com
     identityRef:
       name: openstack-cloud-config
       cloudName: openstack
       region: RegionOne
 ```
+


### PR DESCRIPTION
This patch updates OpenStack template reference to mention `externalNetwork` field as well as `apiServerLoadBalancer` for scenarios when target cloud has multiple external networks and/or doesn't support octavia.

Minor fixes included:
- ClusterDeployment table is again using markdown and contains parametrized template version.
- added `[]` in `securityGroups[]` to denote it accepts list of values.