### PR TITLE
Fixed Quickstart versions. Removed ServiceTemplate

### DIFF
--- a/docs/quickstarts/quickstart-1-mgmt-node-and-cluster.md
+++ b/docs/quickstarts/quickstart-1-mgmt-node-and-cluster.md
@@ -190,13 +190,13 @@ You should see output similar to:
 ```console
 NAME                                   VALID
 cluster-api-{{{ extra.docsVersionInfo.k0rdentVersion }}}                      true
-cluster-api-provider-aws-{{{ extra.docsVersionInfo.k0rdentVersion }}}         true
-cluster-api-provider-azure-{{{ extra.docsVersionInfo.k0rdentVersion }}}       true
-cluster-api-provider-openstack-{{{ extra.docsVersionInfo.k0rdentVersion }}}   true
-cluster-api-provider-vsphere-{{{ extra.docsVersionInfo.k0rdentVersion }}}     true
-k0smotron-{{{ extra.docsVersionInfo.k0rdentVersion }}}                        true
-kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}}                              true
-projectsveltos-0-45-0                  true
+cluster-api-provider-aws-{{{ docsVersionInfo.providerVersions.dashVersions.awsHostedCpCluster }}}         true
+cluster-api-provider-azure-{{{ docsVersionInfo.providerVersions.dashVersions.azureStandaloneCpCluster }}}       true
+cluster-api-provider-openstack-{{{ docsVersionInfo.providerVersions.dashVersions.openstackStandaloneCpCluster }}}   true
+cluster-api-provider-vsphere-{{{ docsVersionInfo.providerVersions.dashVersions.vsphereStandaloneCpCluster }}}     true
+k0smotron-{{{ docsVersionInfo.k0rdentVersion }}}                        true
+kcm-{{{ docsVersionInfo.k0rdentVersion }}}                              true
+projectsveltos-{{{ docsVersionInfo.providerVersions.dashVersions.sveltosProvider }}}                  true
 ```
 
 ## Verify that KCM ClusterTemplate objects are available
@@ -223,26 +223,6 @@ vsphere-hosted-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.vspher
 vsphere-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.vsphereStandaloneCpCluster }}}     true
 ```
 
-## Verify that KSM ServiceTemplate objects are available
-
-{{{ docsVersionInfo.k0rdentName }}} Service Manager (KSM) uses Service Templates to lifecycle manage services and applications installed on clusters. These, too, are represented as declarative templates, instantiated as `ServiceTemplate` objects. Check that default `ServiceTemplate` objects have been created and validated:
-
-```shell
-kubectl get servicetemplate -n kcm-system   # list servicetemplate objects in the kcm-system namespace
-```
-
-You should see output similar to:
-
-```console
-NAME                      VALID
-cert-manager-1-16-2       true
-dex-0-19-1                true
-external-secrets-0-11-0   true
-ingress-nginx-4-11-0      true
-ingress-nginx-4-11-3      true
-kyverno-3-2-6             true
-velero-8-1-0              true
-```
 ## Next steps
 
-Your QuickStart management node is now complete, and {{{ docsVersionInfo.k0rdentName }}} is installed and operational. Next, it's time to select [AWS](quickstart-2-aws.md) or [Azure](quickstart-2-azure.md) as an environment for hosting managed clusters.
+Your QuickStart management node is now complete, and {{{ docsVersionInfo.k0rdentName }}} is installed and operational. Next, it's time to select [AWS](quickstart-2-aws.md), [Azure](quickstart-2-azure.md), [GCP](quickstart-2-gcp.md), or [Remote SSH Servers](quickstart-2-remote.md) as an environment for hosting managed clusters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -312,6 +312,7 @@ extra:
         remoteCluster: 0-2-0
         vsphereHostedCpCluster: 0-2-0
         vsphereStandaloneCpCluster: 0-2-0
+        sveltosProvider: 0-50-0
       dotVersions:
         adoptedCluster: 0.2.0
         awsEksCluster: 0.2.0
@@ -327,6 +328,7 @@ extra:
         remoteCluster: 0.2.0
         vsphereHostedCpCluster: 0.2.0
         vsphereStandaloneCpCluster: 0.2.0
+        sveltosProvider: 0.50.0
     servicesVersions:
       dashVersions:
         certManager: 1-16-2  


### PR DESCRIPTION
Tested and fixed version 0.2.0 templates in initial quickstart instructions. Also removed ServiceTemplates, as they are no longer installed by default.