### PR TITLE
fix a typo in admin/upgrade

### DIFF
--- a/docs/admin/upgrade/index.md
+++ b/docs/admin/upgrade/index.md
@@ -29,7 +29,7 @@ Upgrading {{{ docsVersionInfo.k0rdentName }}} involves making upgrades to the `M
         - name: k0smotron
           template: k0smotron-{{{ extra.docsVersionInfo.k0rdentVersion }}}
         - name: cluster-api-provider-azure
-          template: cluster-api-provider-azure-{{{ extra.docsVersionInfo.k0rdentsion }}}
+          template: cluster-api-provider-azure-{{{ extra.docsVersionInfo.k0rdentVersion }}}
         - name: cluster-api-provider-vsphere
           template: cluster-api-provider-vsphere-{{{ extra.docsVersionInfo.k0rdentVersion }}}
         - name: cluster-api-provider-aws

--- a/docs/admin/upgrade/upgrade-to-0-2-0.md
+++ b/docs/admin/upgrade/upgrade-to-0-2-0.md
@@ -6,8 +6,7 @@ and perform the additional manual steps outlined below:
 
 1. Follow the [upgrading guide](index.md) and create a new `Release` object (steps 1-2).
 
-2. Verify the new `Release` status
-
+2. Verify the new `Release` status. <br><br>
    Wait for the new `Release` to have `status.ready: true`. You can monitor progress using this command:
 
     ```shell


### PR DESCRIPTION
https://docs.k0rdent.io/head/admin/upgrade/

```yaml
[...]
      template: cluster-api-provider-azure-{{ no such element: dict object['k0rdentsion'] }}
[...]
```