### PR TITLE
docs: align with KSM codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 # Ignore extension folders from .vscode
 
 .vscode
+.idea
 
 # Ignore MkDocs build output
 site/

--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -253,7 +253,7 @@
     After the cluster is `Ready`, you can access it via the kubeconfig, just like any other Kubernetes cluster:
 
     ```shell
-    kubectl -n kcm-system get secret my-openstack-cluster-deployment-kubeconfig -o jsonpath='{.data.value>' | base64 -d > my-openstack-cluster-deployment-kubeconfig.kubeconfig
+    kubectl -n kcm-system get secret my-openstack-cluster-deployment-kubeconfig -o jsonpath='{.data.value}' | base64 -d > my-openstack-cluster-deployment-kubeconfig.kubeconfig
     KUBECONFIG="my-openstack-cluster-deployment-kubeconfig.kubeconfig" kubectl get pods -A
     ```
 

--- a/docs/admin/services/admin-create-multiclusterservice.md
+++ b/docs/admin/services/admin-create-multiclusterservice.md
@@ -1,8 +1,6 @@
-# Deploy beach-head services using MultiClusterService
+# Deploy services using MultiClusterService
 
-The `MultiClusterService` object is used to deploy beach-head services on multiple matching clusters.
-These beach-head services provide capabilities, such as Kyverno or Nginx Ingress, that are accessed by
-user applications.
+The `MultiClusterService` object is used to deploy services on multiple matching clusters.
 
 ## Creation
 
@@ -18,8 +16,7 @@ spec:
     matchLabels:
       <key1>: <value1>
       <key2>: <value2>
-      . . .
- serviceSpec:
+  serviceSpec:
     services:
     - template: <servicetemplate-1-name>
       name: <release-name>
@@ -52,7 +49,7 @@ dev-cluster-1                  Provisioned   2h41m             app.kubernetes.io
 dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-2,helm.toolkit.fluxcd.io/namespace=kcm-system,sveltos-agent=present
 ```
 
-The `dev-cluster-1` `ClusterDeployment` beach-head services are specified as:
+The `dev-cluster-1` `ClusterDeployment` services are specified as:
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterDeployment

--- a/docs/admin/services/admin-service-templates.md
+++ b/docs/admin/services/admin-service-templates.md
@@ -6,113 +6,242 @@ You can find more information on [Bringing Your Own Templates](../../reference/t
 in the Template Guide, but this section gives you an idea of how to create a `ServiceTemplate`
 and use it to deploy an application to a {{{ docsVersionInfo.k0rdentName }}} child cluster.
 
-The basic sequence looks like this:
+`ServiceTemplate` supports the following types as a source:
 
-  1. Define the source of the Helm chart that defines the service. The source object must have the label `k0rdent.mirantis.com/managed: "true"`. For example, this YAML describes a custom `Source` object of `kind` `HelmRepository`:
+- [`HelmChart`](https://fluxcd.io/flux/components/source/helmcharts/)
+- [`GitRespository`](https://fluxcd.io/flux/components/source/gitrepositories/)
+- [`Bucket`](https://fluxcd.io/flux/components/source/buckets/)
+- [`OCIRepository`](https://fluxcd.io/flux/components/source/ocirepositories/)
+- `Secret`
+- `ConfigMap`
 
-    ```yaml
-    apiVersion: source.toolkit.fluxcd.io/v1
-    kind: HelmRepository
-    metadata:
-      name: custom-templates-repo
-      namespace: kcm-system
-      labels:
-        k0rdent.mirantis.com/managed: "true"
-    spec:
-      insecure: true
+### Creating Helm-based ServiceTemplate
+
+> NOTE:
+> Only [`HelmRepository`](https://fluxcd.io/flux/components/source/helmrepositories/) support as a source for `HelmChart`.
+
+Define the source of the Helm chart that defines the service. The source object must have the label `k0rdent.mirantis.com/managed: "true"`. For example, this YAML describes a custom `Source` object of `kind` `HelmRepository`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: custom-templates-repo
+  namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/managed: "true"
+spec:
+  insecure: true
+  interval: 10m0s
+  provider: generic
+  type: oci
+  url: oci://ghcr.io/external-templates-repo/charts
+```
+
+#### Create the `ServiceTemplate`
+
+A template can either define a Helm chart directly using the template's `spec.helm.chartSpec` field or reference its location using the `spec.helm.chartRef` field.
+
+For example:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: project-ingress-nginx-4.11.3
+  namespace: my-target-namespace
+spec:
+  helm:
+    chartSpec:
+      chart: ingress-nginx
+      version: 4.11.3
       interval: 10m0s
-      provider: generic
-      type: oci
-      url: oci://ghcr.io/external-templates-repo/charts
-    ```
+      sourceRef:
+        kind: HelmRepository
+        name: k0rdent-catalog
+```
 
-  2. Create the `ServiceTemplate`
+In this case, we're creating a `ServiceTemplate` called `ingress-nginx-4.11.3` in the
+`my-target-namespace` namespace.  It references version 4.11.3 of the `ingress-nginx` chart
+located in the `k0rdent-catalog` Helm repository.
 
-    A template can either define a Helm chart directly using the template's `spec.helm.chartSpec` field or reference its location using the `spec.helm.chartRef` field.
+For more information on creating templates, see the [Template Guide](../../reference/template/index.md).
 
-    For example:
+### Creating Kustomization-based ServiceTemplate
 
-    ```yaml
-    apiVersion: k0rdent.mirantis.com/v1alpha1
-    kind: ServiceTemplate
+Define the source of the Kustomization that defines the service. If the source object is one of Flux source - `GitRepository`, `Bucket` or `OCIRepository` - it must
+have the label `k0rdent.mirantis.com/managed: "true"`.
+
+Source object can be already created. In this case `.spec.kustomization.localSourceRef` should be used:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: kustomization-app
+  namespace: kcm-system
+spec:
+  kustomize:
+    localSourceRef:
+      kind: GitRepository
+      name: project-x
+    deploymentType: Remote
+    path: "./base"
+```
+
+Aside from flux sources, local `ConfigMap` or `Secret` object can be used as a source of the kustomization manifests. The `ServiceTemplate` definition will not differ
+from one in above, except the `.spec.kustomize.localSourceRef.kind` which should be set to respective object type. However, to use `ConfigMap` or `Secret` as a source, they must
+embed archive with kustomization. After the archive was created, this can be done by executing the following command:
+
+```shell
+kubectl create configmap kustomization-source --from-file=/path/to/kustomization.tar.gz
+```
+
+Another option is to let the controller to create the remote source object. In this case `.spec.kustomization.remoteSourceSpec` should be used:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: kustomization-app
+  namespace: kcm-system
+spec:
+  kustomize:
+    remoteSourceSpec:
+      oci:
+        url: oci://ghcr.io/org/project-x
+        reference:
+          tag: latest
+        interval: 10m
+    deploymentType: Remote
+    path: "./overlays"
+```
+
+When `.spec.kustomize.remoteSourceSpec` is defined, the controller will create corresponding object.
+
+### Creating Raw-Resources-based ServiceTemplate
+
+This type of source is quite similar to the kustomization sources, with the only exception: 
+when using `ConfigMap` or `Secret` as a source, the field `.spec.resources.localSourceRef.path` will be ignored 
+and the resources' manifests to be deployed must be inlined in the source's `data`.
+
+Example of the `ConfigMap` and corresponding `ServiceTemplate`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-cm
+  namespace: project-x
+data:
+  namespace.yaml: |
+    apiVersion: v1
+    kind: Namespace
     metadata:
-      name: project-ingress-nginx-4.11.3
-      namespace: my-target-namespace
-    spec:
-      helm:
-        chartSpec:
-          chart: ingress-nginx
-          version: 4.11.3
-          interval: 10m0s
-          sourceRef:
-            kind: HelmRepository
-            name: k0rdent-catalog
-    ```
+      name: managed-ns
+```
 
-    In this case, we're creating a `ServiceTemplate` called `ingress-nginx-4.11.3` in the
-    `my-target-namespace` namespace.  It references version 4.11.3 of the `ingress-nginx` chart
-    located in the `k0rdent-catalog` Helm repository.
+To create such `ConfigMap` the following command can be used:
 
-    For more information on creating templates, see the [Template Guide](../../reference/template/index.md).
+```shell
+kubectl --namespace project-x create configmap project-cm --from-file=/path/to/namespace.yaml
+```
 
-  3. Create a `ServiceTemplateChain`
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: managed-ns
+  namespace: project-x
+spec:
+  resources:
+    localSourceRef:
+      kind: ConfigMap
+      name: project-cm
+    deploymentType: Remote
+    path: ""  # will be ignored
+```
 
-    To let {{{ docsVersionInfo.k0rdentName }}} know where this `ServiceTemplate` can and can't be used, create a `ServiceTemplateChain` object, as in:
+Using the remote source for `ServiceTemplate` based on raw resources is similar to the kustomization-based template:
 
-    ```yaml
-    apiVersion: k0rdent.mirantis.com/v1alpha1
-    kind: ServiceTemplateChain
-    metadata:
-      name: project-ingress-nginx-4.11.3
-      namespace: my-target-namespace
-    spec:
-      supportedTemplates:
-        - name: project-ingress-nginx-4.11.3
-        - name: project-ingress-nginx-4.10.0
-          availableUpgrades:
-            - name: project-ingress-nginx-4.11.3
-    ```
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: kustomization-app
+  namespace: kcm-system
+spec:
+  resources:
+    remoteSourceSpec:
+      git:
+        url: https://github.com/org/project-x.git
+        reference:
+          branch: main
+        interval: 10m
+    deploymentType: Remote
+    path: "./overlays"
+```
 
-    Here you see a template called `project-ingress-nginx-4.11.3` that is meant to be deployed in the `my-target-namespace` namespace.
-    The `.spec.helm.chartSpec` specifies the name of the Helm chart and where to find it, as well as the version and other 
-    important information. The `ServiceTempateChain` shows that this template is also an upgrade path from version 4.10.0.
+### Deploying Application with ServiceTemplate
 
-    If you wanted to deploy this as an application, you would first go ahead and add it to the cluster in which you were
-    working, so if you were to save this YAML to a file called `project-ingress.yaml` you could run this command on the management cluster:
+#### Create a `ServiceTemplateChain`
 
-    ```shell
-    kubectl apply -f project-ingress.yaml -n my-target-namespace
-    ```
+To let {{{ docsVersionInfo.k0rdentName }}} know where this `ServiceTemplate` can and can't be used, create a `ServiceTemplateChain` object, as in:
 
-  4. Adding a `Service` to a `ClusterDeployment`
+ ```yaml
+ apiVersion: k0rdent.mirantis.com/v1alpha1
+ kind: ServiceTemplateChain
+ metadata:
+   name: project-ingress-nginx-4.11.3
+   namespace: my-target-namespace
+ spec:
+   supportedTemplates:
+     - name: project-ingress-nginx-4.11.3
+     - name: project-ingress-nginx-4.10.0
+       availableUpgrades:
+         - name: project-ingress-nginx-4.11.3
+ ```
 
-    To add the service defined by this template to a cluster, you would simply add it to the `ClusterDeployment` object
-    when you create it, as in:
+Here you see a template called `project-ingress-nginx-4.11.3` that is meant to be deployed in the `my-target-namespace` namespace.
+The `.spec.helm.chartSpec` specifies the name of the Helm chart and where to find it, as well as the version and other
+important information. The `ServiceTempateChain` shows that this template is also an upgrade path from version 4.10.0.
 
-    ```yaml
-    apiVersion: k0rdent.mirantis.com/v1alpha1
-    kind: ClusterDeployment
-    metadata:
-      name: my-cluster-deployment
-      namespace: tenant42
-    spec:
-      config:
-        clusterLabels: {}
-      template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
-      credential: aws-credential
-      serviceSpec:
-        services:
-          - template: project-ingress-nginx-4.11.3
-            name: ingress-nginx
-            namespace: my-target-namespace
-        priority: 100
-    ```
-    As you can see, you're simply referencing the template in the `.spec.serviceSpec.services[].template` field of the `ClusterDeployment`
-    to tell {{{ docsVersionInfo.k0rdentName }}} that you want this service to be part of this cluster.
+If you wanted to deploy this as an application, you would first go ahead and add it to the cluster in which you were
+working, so if you were to save this YAML to a file called `project-ingress.yaml` you could run this command on the management cluster:
 
-    If you wanted to add this service to an existing cluster, you would simply patch the definition of the `ClusterDeployment`, as in:
+ ```shell
+ kubectl apply -f project-ingress.yaml -n my-target-namespace
+ ```
 
-    ```shell
-    kubectl patch clusterdeployment my-cluster-deployment -n my-target-namespace --type='merge' -p '{"spec":{"services":[{"template":"project-ingress-nginx-4.11.3","name":"ingress-nginx","namespace":"my-target-namespace"}]}}'
-    ```
-    For more information on creating and using `ServiceTemplate` objects, see the [User Guide](../../user/services/index.md).
+#### Adding a `Service` to a `ClusterDeployment`
+
+To add the service defined by this template to a cluster, you would simply add it to the `ClusterDeployment` object
+when you create it, as in:
+
+ ```yaml
+ apiVersion: k0rdent.mirantis.com/v1alpha1
+ kind: ClusterDeployment
+ metadata:
+   name: my-cluster-deployment
+   namespace: tenant42
+ spec:
+   config:
+     clusterLabels: {}
+   template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
+   credential: aws-credential
+   serviceSpec:
+     services:
+       - template: project-ingress-nginx-4.11.3
+         name: ingress-nginx
+         namespace: my-target-namespace
+     priority: 100
+ ```
+As you can see, you're simply referencing the template in the `.spec.serviceSpec.services[].template` field of the `ClusterDeployment`
+to tell {{{ docsVersionInfo.k0rdentName }}} that you want this service to be part of this cluster.
+
+If you wanted to add this service to an existing cluster, you would simply patch the definition of the `ClusterDeployment`, as in:
+
+ ```shell
+ kubectl patch clusterdeployment my-cluster-deployment -n my-target-namespace --type='merge' -p '{"spec":{"services":[{"template":"project-ingress-nginx-4.11.3","name":"ingress-nginx","namespace":"my-target-namespace"}]}}'
+ ```
+For more information on creating and using `ServiceTemplate` objects, see the [User Guide](../../user/services/index.md).

--- a/docs/admin/services/admin-service-templates.md
+++ b/docs/admin/services/admin-service-templates.md
@@ -20,7 +20,7 @@ and use it to deploy an application to a {{{ docsVersionInfo.k0rdentName }}} chi
 > NOTE:
 > Only [`HelmRepository`](https://fluxcd.io/flux/components/source/helmrepositories/) support as a source for `HelmChart`.
 
-Define the source of the Helm chart that defines the service. The source object must have the label `k0rdent.mirantis.com/managed: "true"`. For example, this YAML describes a custom `Source` object of `kind` `HelmRepository`:
+Define the source of the Helm chart that defines the service. The source object must have the label `k0rdent.mirantis.com/managed: "true"`. For example, this YAML describes a FluxCD source object of `kind` `HelmRepository`:
 
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -242,6 +242,6 @@ to tell {{{ docsVersionInfo.k0rdentName }}} that you want this service to be par
 If you wanted to add this service to an existing cluster, you would simply patch the definition of the `ClusterDeployment`, as in:
 
  ```shell
- kubectl patch clusterdeployment my-cluster-deployment -n my-target-namespace --type='merge' -p '{"spec":{"services":[{"template":"project-ingress-nginx-4.11.3","name":"ingress-nginx","namespace":"my-target-namespace"}]}}'
+ kubectl patch clusterdeployment my-cluster-deployment -n my-target-namespace --type='merge' -p '{"spec":{"serviceSpec":{"services":[{"template":"project-ingress-nginx-4.11.3","name":"ingress-nginx","namespace":"my-target-namespace"}]}}}'
  ```
 For more information on creating and using `ServiceTemplate` objects, see the [User Guide](../../user/services/index.md).

--- a/docs/admin/services/index.md
+++ b/docs/admin/services/index.md
@@ -1,7 +1,7 @@
 # Working With Services
 
 {{{ docsVersionInfo.k0rdentName }}} considers applications to be "services".  These services may be traditional services, such
-as Nginx Ingress, or they can be user-ceated applications. To deploy these applications, create a 
+as Nginx Ingress, or they can be user-created applications. To deploy these applications, create a 
 `ServiceTemplate` and deploy an instance of it.
 
 - [Using and creating service templates](admin-service-templates.md)

--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -63,8 +63,7 @@ updates, and other CRUD operations.
 Cluster and beach-head services monitoring, events and log management.
 
 ## k0rdent State Manager (KSM)
-Installation and life-cycle management of beach-head services, policy, Kubernetes API 
-configurations and more.
+Installation and life-cycle management of deployed services.
 
 ## Hosted Control Plane (HCP)
 An HCP is a Kubernetes control plane that runs outside of the clusters it manages. 
@@ -81,8 +80,7 @@ Kubernetes clusters. It enables Cluster API (CAPI) to provision and manage clust
 a specific infrastructure platform (e.g., AWS, Azure, VMware, OpenStack, etc.).
 
 ## Multi-Cluster Service
-The `MultiClusterService` is a custom resource used to manage deployment of beach-head 
-services across multiple clusters.
+The `MultiClusterService` is a custom resource used to manage services' deployment across multiple clusters.
 
 ## Management Cluster
 The Kubernetes cluster where {{{ docsVersionInfo.k0rdentName }}} is installed and from which all other managed 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,7 @@ The project has a number of components, including:
 
     * **k0rdent State Manager (KSM)**
 
-        Installation and life-cycle management of [beach-head services](appendix/glossary.md#beach-head-services),
-        policy, Kubernetes API configurations, and more.
+        Installation and life-cycle management of deployed services.
 
           * This is currently rolled into kcm, but may be split out in the future
           * ksm leverages [Project Sveltos](https://github.com/projectsveltos/sveltos)

--- a/docs/reference/template/template-byo.md
+++ b/docs/reference/template/template-byo.md
@@ -7,13 +7,32 @@ In addition to the templates that ship with {{{ docsVersionInfo.k0rdentName }}},
 > INFO:
 > Skip this step if you're using an existing source.
 
-All templates are based on a Helm chart, so the first step is to define the source in which that Helm chart can be found.
+`ClusterTemplate` and `ProviderTemplate` are based on a Helm chart. `ServiceTemplate`, apart from Helm chart, can be also based on kustomization or raw resources.
+Regardless of the type of the resources to be deployed using template, the corresponding source object should be created.
 
 The source can be one of the following types:
+
+| **Template**       | `HelmRepository` | `Bucket` | `OCIRepository` | `ConfigMap` | `Secret` |
+|--------------------|------------------|----------|-----------------|-------------|----------|
+| `ClusterTemplate`  | V                | X        | X               | X           | X        |
+| `ProviderTemplate` | V                | X        | X               | X           | X        |
+| `ServiceTemplate`  | V                | V        | V               | V           | V        |
 
 - [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/)
 - [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/)
 - [Bucket](https://fluxcd.io/flux/components/source/buckets/)
+
+> INFO: 
+> `ConfigMap` and `Secret` can only be used as a source of kustomization or raw resources for `ServiceTemplate`.
+> To deploy kustomization using `ConfigMap` or `Secret` the kustomization folder must be archived in *.tar.gz and
+> then `ConfigMap` or `Secret` must be created from resulting archive:
+> ```console
+> kubectl create configmap foo --from-file=kustomization.tar.gz
+> ```
+> To deploy raw resources using `ConfigMap` or `Secret` source object must be created from raw resource files:
+> ```console
+> kubectl create configmap bar --from-file=namespace.yaml --from-file=deployment.yaml
+> ```
 
 Note that it's important to pay attention to where the source resides. Cluster-scoped `ProviderTemplate` objects must reside in the **system** namespace (`kcm-system` by default) but other template sources must reside in the same namespace as the templates that will come from them.
 
@@ -50,10 +69,11 @@ Once you have the source, you can create the actual template. This template can 
 For `ClusterTemplate` and `ServiceTemplate` objects, configure the namespace where this template should reside
 (`metadata.namespace`).
 
+For defining the Helm chart, you have three choices. You can either:
 
-For defining the Helm chart, you have two choices. You can either specify the actual helm chart definition in the `.spec.helm.chartSpec` field of the
-[HelmChartSpec](https://fluxcd.io/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.HelmChartSpec) kind, or
-you can reference and existing `HelmChart` object in `.spec.helm.chartRef`.
+1. Specify the actual Helm chart definition in the `.spec.helm.chartSpec` field of the
+   [HelmChartSpec](https://fluxcd.io/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.HelmChartSpec) kind,
+2. Reference an existing `HelmChart` object in `.spec.helm.chartRef`, or
 
 > NOTE:
 > `spec.helm.chartSpec` and `spec.helm.chartRef` are mutually exclusive.
@@ -61,12 +81,12 @@ you can reference and existing `HelmChart` object in `.spec.helm.chartRef`.
 To automatically create the `HelmChart` for the `Template`, configure the following custom helm chart parameters
 under `spec.helm.chartSpec`:
 
-| **Field**                                                                                                                                                   | **Description**                                                                                                              |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| **Field**                                                                                                                                                   | **Description**                                                                                                                     |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `sourceRef`<br/>[LocalHelmChartSourceReference](https://fluxcd.io/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.LocalHelmChartSourceReference) | Reference to the source object (for example, `HelmRepository`, `GitRepository`, or `Bucket`) in the same namespace as the Template. |
-| `chart`<br/>string                                                                                                                                          | The name of the Helm chart available in the source.                                                                          |
-| `version`<br/>string                                                                                                                                        | Version is the chart version semver expression. Defaults to **latest** when omitted.                                         |
-| `interval`<br/>[Kubernetes meta/v1.Duration](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration)                                              | The frequency at which the `sourceRef` is checked for updates. Defaults to **10 minutes**.                                   |
+| `chart`<br/>string                                                                                                                                          | The name of the Helm chart available in the source.                                                                                 |
+| `version`<br/>string                                                                                                                                        | Version is the chart version semver expression. Defaults to **latest** when omitted.                                                |
+| `interval`<br/>[Kubernetes meta/v1.Duration](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration)                                              | The frequency at which the `sourceRef` is checked for updates. Defaults to **10 minutes**.                                          |
 
 For the complete list of the `HelmChart` parameters, see:
 [HelmChartSpec](https://fluxcd.io/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.HelmChartSpec).
@@ -81,44 +101,65 @@ The controller automatically creates the `HelmChart` object based on the chartSp
 > system namespace (defaults to `kcm-system`). To get the instructions on how to distribute Templates along multiple
 > namespaces, read [Template Life Cycle Management](index.md#template-life-cycle-management).
 
-### Examples
+### Alternative Template Sources
 
-> EXAMPLE: 
-> Custom `ClusterTemplate` with the Chart Definition to Create a new HelmChart
+Aside from Helm charts, `ServiceTemplate` also supports alternative resource definitions using either Kustomize or raw resources.
+
+You can use one of the following fields in `.spec` (they are mutually exclusive):
+
+- `.spec.kustomize`
+- `.spec.resources`
+
+Each of these fields accepts a `SourceSpec`, which defines the origin of the template content. Only one can be used at a time.
+
+A `SourceSpec` includes:
+
+| **Field**          | **Description**                                                                                                                                 |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `deploymentType`   | Must be either `Local` or `Remote`. Defines whether resources will be deployed to management (local) or to managed (remote) cluster.            |
+| `localSourceRef`   | Reference to a local source (e.g., `ConfigMap`, `Secret`, `GitRepository`, `Bucket`, `OCIRepository`).                                          |
+| `remoteSourceSpec` | Configuration for a remote source. Includes support for `Git`, `Bucket`, or `OCI` repositories.                                                 |
+| `path`             | Path within the source object pointing to the manifests or kustomize config. Ignored when deploying raw resources using `ConfigMap` or `Secret` |
+
+> NOTE:
+> Fields `.spec.*.remoteSourceSpec.git`, `.spec.*.remoteSource.Spec.bucket` and `.spec.*.remoteSourceSpec.oci` are mutually exclusive.
+
+Example using `.spec.kustomize`:
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ClusterTemplate
+kind: ServiceTemplate
 metadata:
-  name: custom-template
-  namespace: kcm-system
+   name: example-kustomization
+   namespace: kcm-system
 spec:
-  providers:
-    - bootstrap-k0sproject-k0smotron
-    - control-plane-k0sproject-k0smotron
-    - infrastructure-openstack
-  helm:
-    chartSpec:
-      chart: os-k0sproject-k0smotron
-      sourceRef:
-        kind: HelmRepository
-        name: k0rdent-catalog
+  kustomize:
+    deploymentType: Remote
+    remoteSourceSpec:
+      git:
+        url: https://github.com/example/repo
+        ref:
+          branch: main
+    path: ./overlays/dev
 ```
 
-> EXAMPLE: 
-> Custom `ClusterTemplate` Referencing an Existing HelmChart object
->
+Example using `.spec.resources`:
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ClusterTemplate
+kind: ServiceTemplate
 metadata:
-  name: custom-template
-  namespace: kcm-system
+   name: example-resources
+   namespace: kcm-system
 spec:
-  helm:
-    chartRef:
-      kind: HelmChart
-      name: custom-chart
+  resources:
+    deploymentType: Local
+    localSourceRef:
+      kind: ConfigMap
+      name: my-configmap
+    path: ./manifests
 ```
+
+All of the above follow the same mutual exclusivity and version constraint rules as Helm.
+
 
 ## Required and exposed providers definition
 

--- a/docs/reference/template/template-byo.md
+++ b/docs/reference/template/template-byo.md
@@ -15,7 +15,7 @@ The source can be one of the following types:
 - [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/)
 - [Bucket](https://fluxcd.io/flux/components/source/buckets/)
 
-Note that it's important to pay attention to where the source resides. Cluster-scoped `ProviderTemplate` objects must reside in the **system** namespace (`kcm-system` by default) but other template sources must reside in the same directory as the templates that will come from them.
+Note that it's important to pay attention to where the source resides. Cluster-scoped `ProviderTemplate` objects must reside in the **system** namespace (`kcm-system` by default) but other template sources must reside in the same namespace as the templates that will come from them.
 
 For example, this YAML describes a custom `Source` object of `kind` `HelmRepository`:
 

--- a/docs/user/services/understanding-servicetemplates.md
+++ b/docs/user/services/understanding-servicetemplates.md
@@ -1,44 +1,110 @@
 # Understanding ServiceTemplates
 
-`ServiceTemplate` objects are meant to let {{{ docsVersionInfo.k0rdentName }}} know where to find a Helm chart with instructions for installing
-an application. In many cases, these charts will be in a private repository.  For example, consider this template for
-installing Nginx Ingress:
+`ServiceTemplate` objects are a representation of the source where {{{ docsVersionInfo.k0rdentName }}} can find a resource or set of resources to
+be deployed as a complete application.
 
-```yaml
-apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ServiceTemplate
-metadata:
-  name: project-ingress-nginx-4.11.0
-  namespace: tenant42
-spec:
-  helm:
-    chartSpec:
-      chart: demo-ingress-nginx
-      version: 4.11.0
-      interval: 10m0s
-      sourceRef:
-        kind: HelmRepository
-        name: k0rdent-demos
----
-apiVersion: k0rdent.mirantis.com/v1alpha1
-kind: ServiceTemplateChain
-metadata:
-  name: project-ingress-nginx-4.11.0
-  namespace: tenant42
-spec:
-  supportedTemplates:
-    - name: project-ingress-nginx-4.11.0
-    - name: project-ingress-nginx-4.10.0
-      availableUpgrades:
-        - name: project-ingress-nginx-4.11.0
-```
+`ServiceTemplate` supports the following types as a source:
 
-Here you see a template called `project-ingress-nginx-4.11.0` that is meant to be deployed in the `tenant42` namespace.
-The `.spec.helm.chartSpec` specifies the name of the Helm chart and where to find it, as well as the version and other 
-important information. The `ServiceTemplateChain` shows that this template is also an upgrade path from version 4.10.0.
+- [`HelmChart`](https://fluxcd.io/flux/components/source/helmcharts/)
+- [`GitRespository`](https://fluxcd.io/flux/components/source/gitrepositories/)
+- [`Bucket`](https://fluxcd.io/flux/components/source/buckets/)
+- [`OCIRepository`](https://fluxcd.io/flux/components/source/ocirepositories/)
+- `Secret`
+- `ConfigMap`
 
-If you wanted to deploy this as an application, you would first go ahead and add the template to the cluster in which you were working, so if you were to save this YAML to a file called `project-ingress.yaml` you could run this command on the management cluster:
+### Helm-based ServiceTemplate
 
-```shell
-kubectl apply -f project-ingress.yaml -n tenant42
-```
+Helm-based `ServiceTemplate` can be created in two ways:
+
+- by defining Helm chart right in the template object
+
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: foo
+    namespace: bar
+  spec:
+    helm:
+      chartSpec:
+        chart: ingress-nginx
+        version: 4.11.0
+        interval: 10m
+        sourceRef:
+          kind: HelmRepository
+          name: foo-repository
+  ```
+  
+  In this case the corresponding `HelmChart` object will be created by the controller.
+
+- by referring the existing Helm chart
+
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: foo
+    namespace: bar
+  spec:
+    helm:
+      chartRef:
+        kind: HelmChart
+        name: foo-chart
+  ```
+
+### Kustomize-based ServiceTemplate
+
+Kustomize-based `ServiceTemplate` can be created with either local or remote source:
+
+- by using existing flux source object - `GitRepository`, `Bucket` or `OCIRepository` - or using existing `ConfigMap` or `Secret`
+
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: foo
+    namespace: bar
+  spec:
+    kustomize:
+      localSourceRef:
+        kind: Bucket  # also can be GitRepository, OCIRepository, ConfigMap or Secret
+        name: foo-bar
+      deploymentType: Remote
+      path: "./base"
+  ```
+  
+  `ConfigMap` or `Secret` in this case must embed the tar-gzipped archive containing the kustomization files. This can be done by the following command, assuming the the archive was already created:
+
+  ```shell
+  kubectl create configmap foo-bar --from-file=/path/to/kustomization/archive.tar.gz
+  ```
+
+- by defining remote source right in the template object
+
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: kustomization-app
+    namespace: kcm-system
+  spec:
+    kustomize:
+      remoteSourceSpec:
+        oci:
+          url: oci://ghcr.io/org/project-x
+          reference:
+            tag: latest
+          interval: 10m
+      deploymentType: Remote
+      path: "./overlays"
+  ```
+  
+  `.spec.kustomize.remoteSourceSpec` has mutual exclusive fields `.git`, `.bucket` and `.oci` which inline `GitRepositorySpec`, `BucketSpec` and `OCIRepositorySpec` respectively.
+
+### Raw-resources-based ServiceTemplate
+
+Similar to kustomize-based `ServiceTemplate`, raw-resources-based `ServiceTemplate` can be created with either local or remote source. Using the remote source has no difference with
+kustomize-based `ServiceTemplate`, however using local source slightly differ in case `ConfigMap` or `Secret` object is referred as a source:
+
+- `spec.resources.localSourceRef.path` will be ignored
+- referred `ConfigMap` or `Secret` must contain inlined resources' definitions instead of embedding tar-gzipped archive. 


### PR DESCRIPTION
This PR updates `ServiceTemplate`-related documentation so that it will be aligned with current codebase.

Fixes: k0rdent/kcm#1330