### PR TITLE
docs: helm sources for ServiceTemplates

### DIFF
--- a/docs/reference/template/template-byo.md
+++ b/docs/reference/template/template-byo.md
@@ -109,17 +109,18 @@ You can use one of the following fields in `.spec` (they are mutually exclusive)
 
 - `.spec.kustomize`
 - `.spec.resources`
+- `.spec.helm.chartSource`
 
 Each of these fields accepts a `SourceSpec`, which defines the origin of the template content. Only one can be used at a time.
 
 A `SourceSpec` includes:
 
-| **Field**          | **Description**                                                                                                                                 |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `deploymentType`   | Must be either `Local` or `Remote`. Defines whether resources will be deployed to management (local) or to managed (remote) cluster.            |
-| `localSourceRef`   | Reference to a local source (e.g., `ConfigMap`, `Secret`, `GitRepository`, `Bucket`, `OCIRepository`).                                          |
-| `remoteSourceSpec` | Configuration for a remote source. Includes support for `Git`, `Bucket`, or `OCI` repositories.                                                 |
-| `path`             | Path within the source object pointing to the manifests or kustomize config. Ignored when deploying raw resources using `ConfigMap` or `Secret` |
+| **Field**          | **Description**                                                                                                                                                                      |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `deploymentType`   | Must be either `Local` or `Remote`. Defines whether resources will be deployed to management (local) or to managed (remote) cluster. Ignored if defined in `.spec.helm.chartSource`. |
+| `localSourceRef`   | Reference to a local source (e.g., `ConfigMap`, `Secret`, `GitRepository`, `Bucket`, `OCIRepository`). `ConfigMap` and `Secret` are not supported in `.spec.helm.chartSource`.       |
+| `remoteSourceSpec` | Configuration for a remote source. Includes support for `Git`, `Bucket`, or `OCI` repositories.                                                                                      |
+| `path`             | Path within the source object pointing to the manifests or kustomize config. Ignored when deploying raw resources using `ConfigMap` or `Secret`                                      |
 
 > NOTE:
 > Fields `.spec.*.remoteSourceSpec.git`, `.spec.*.remoteSource.Spec.bucket` and `.spec.*.remoteSourceSpec.oci` are mutually exclusive.

--- a/docs/user/services/understanding-servicetemplates.md
+++ b/docs/user/services/understanding-servicetemplates.md
@@ -14,7 +14,7 @@ be deployed as a complete application.
 
 ### Helm-based ServiceTemplate
 
-Helm-based `ServiceTemplate` can be created in two ways:
+Helm-based `ServiceTemplate` can be created in three ways:
 
 - by defining Helm chart right in the template object
 
@@ -50,6 +50,47 @@ Helm-based `ServiceTemplate` can be created in two ways:
       chartRef:
         kind: HelmChart
         name: foo-chart
+  ```
+
+- by defining Helm chart source, which can be one of types provided by FluxCD:
+
+  - [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/)
+  - [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/)
+  - [Bucket](https://fluxcd.io/flux/components/source/buckets/)
+
+  Source can already exist or can be created by the controller.
+
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: foo
+    namespace: bar
+  spec:
+    helm:
+      chartSource:
+        localSourceRef:
+          kind: GitRepository
+          name: foo-repository
+        path: "./charts"
+  ```
+  
+  ```yaml
+  apiVersion: k0rdent.mirantis.com/v1alpha1
+  kind: ServiceTemplate
+  metadata:
+    name: foo
+    namespace: bar
+  spec:
+    helm:
+      chartSource:
+        remoteSourceRef:
+          git:
+            url: https://github.com/bar/foo.git
+            reference:
+              branch: main
+            interval: 10m
+          path: "./charts"
   ```
 
 ### Kustomize-based ServiceTemplate


### PR DESCRIPTION
This PR contains documentation related KSM feature to use different Flux sources as a source of Helm charts.

Documentation for functionality which will be introduced in k0rdent OSS v0.3.0

Closes: k0rdent/kcm#1320