### PR TITLE
docs: correct Quickstart typos and small inconsistencies

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -98,8 +98,7 @@ You can find more information on creating these `Credential` objects in [the Cre
 
 At its heart, {{{ docsVersionInfo.k0rdentName }}} is a Kubernetes-native way to declaratively specify what should be happening in the infrastructure and
 have that maintained. In other words, if you want to, say, scale up a cluster, you would give that cluster a new
-definition that includes the additional nodes, and then {{{ docsVersionInfo.k0rdentName }}}, seeing that reality no longer the definition,
-will make it happen.
+definition that includes the additional nodes, and then {{{ docsVersionInfo.k0rdentName }}}, seeing that reality no longer matches the definition, it will [reconcile](https://kubebyexample.com/learning-paths/operator-framework/operator-sdk-go/controller-reconcile-function) the difference.
 
 In some ways this way of working is similar to GitOps, in which you commit definitions and tools such as Flux or ArgoCD
 ensure that reality matches the definition. We can say that {{{ docsVersionInfo.k0rdentName }}} is GitOps-compatible, in the sense that you can (and should) consider storing {{{ docsVersionInfo.k0rdentName }}} templates and YAML object definitions in Git repos, and can (and may want to) use GitOps tools like ArgoCD to modify and manage them upstream of {{{ docsVersionInfo.k0rdentName }}} itself.

--- a/docs/quickstarts/quickstart-2-aws.md
+++ b/docs/quickstarts/quickstart-2-aws.md
@@ -285,7 +285,7 @@ kubectl apply -f aws-cluster-identity-secret.yaml -n kcm-system
 
 Next, we need to create an `AWSClusterStaticIdentity` object that uses the secret.
 
-To do this, create a YAML file named `aws-cluster-identity` as follows:
+To do this, create a YAML file named `aws-cluster-identity.yaml` as follows:
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/docs/quickstarts/quickstart-2-azure.md
+++ b/docs/quickstarts/quickstart-2-azure.md
@@ -142,6 +142,12 @@ Apply the YAML to the {{{ docsVersionInfo.k0rdentName }}} management cluster usi
 kubectl apply -f azure-cluster-identity-secret.yaml
 ```
 
+You should see output resembling this:
+
+```console
+secret/azure-cluster-identity-secret created
+```
+
 ## Create the AzureClusterIdentity Object
 <!--
 > INFO:

--- a/docs/quickstarts/quickstart-2-gcp.md
+++ b/docs/quickstarts/quickstart-2-gcp.md
@@ -80,26 +80,27 @@ Create a `Secret` object that stores the `credentials` field under `data` sectio
 To get base64 encoded credentials, run:
 
 ```bash
-    cat <gcpJSONCredentialsFileName> | base64 -w 0
+    GCP_B64ENCODED_CREDENTIALS=$(cat <gcpJSONCredentialsFileName> | base64 -w 0)
 ```
 
 ```yaml
+cat > gcp-cluster-identity-secret.yaml << EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gcp-cloud-sa
-  namespace: kcm-system
-  labels:
-    k0rdent.mirantis.com/component: "kcm"
+  name: gcp-cloud-sa
+  namespace: kcm-system
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
 data:
-  # the secret key should always equal `credentials`
-  credentials: GCP_B64ENCODED_CREDENTIALS
+  credentials: ${GCP_B64ENCODED_CREDENTIALS}
 type: Opaque
+EOF
 ```
-Create a YAML with the specification of the secret and save it as `gcp-cloud-sa.yaml`.
+Apply the YAML to your cluster:
 
 ```shell
-kubectl apply -f gcp-cloud-sa.yaml
+kubectl apply -f gcp-cluster-identity-secret.yaml
 ```
 
 You should see output resembling this:


### PR DESCRIPTION
Fixed a couple of typos, improved consistency among the Quickstart heredoc syntax, and replaced _make it happen_ phrase with a reference to Kubernetes _reconcile_ 