### PR TITLE
docs: add Preparing for backup to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
         - Role Definitions: admin/access/rbac/roles-summary.md
     - Backup and Restore:
       - Overview: admin/backup/index.md
+      - Preparing for Backup: admin/backup/prepare-backups.md
       - Scheduled Management Backups: admin/backup/scheduled-backups.md
       - Management Backup on Demand: admin/backup/ondemand-backups.md
       - What's Included in a Backup: admin/backup/whats-included.md


### PR DESCRIPTION
The preparation steps were removed and moved to another document, but no nav was added. Adding nav so prep steps are available.