### PR TITLE
docs: kof 1.0.0

### DIFF
--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -244,7 +244,7 @@ and apply this example for AWS, or use it as a reference:
 
     ```shell
     cat >regional-cluster.yaml <<EOF
-    apiVersion: k0rdent.mirantis.com/v1alpha1
+    apiVersion: k0rdent.mirantis.com/v1beta1
     kind: ClusterDeployment
     metadata:
       name: $REGIONAL_CLUSTER_NAME
@@ -279,7 +279,7 @@ and apply this example for AWS, or use it as a reference:
     echo "AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID"
 
     cat >regional-cluster.yaml <<EOF
-    apiVersion: k0rdent.mirantis.com/v1alpha1
+    apiVersion: k0rdent.mirantis.com/v1beta1
     kind: ClusterDeployment
     metadata:
       name: $REGIONAL_CLUSTER_NAME
@@ -370,26 +370,32 @@ and apply this example for AWS, or use it as a reference:
     k0rdent.mirantis.com/kof-write-traces-endpoint: https://jaeger.$REGIONAL_DOMAIN/collector
     ```
 
-9. The `MultiClusterService` named [kof-regional-cluster](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-regional/templates/regional-multi-cluster-service.yaml)
+9. If you need a custom http client configuration for `PromxyServerGroup` and `GrafanaDatasource`,
+    add it to the `regional-cluster.yaml` file in the `.metadata.annotations`, for example:
+    ```yaml
+    k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "10s", "tls_config": {"insecure_skip_verify": true}}'
+    ```
+
+10. The `MultiClusterService` named [kof-regional-cluster](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-regional/templates/regional-multi-cluster-service.yaml)
     configures and installs `cert-manager`, `ingress-nginx`, `kof-storage`, `kof-operators`, and `kof-collectors` charts automatically.
     To pass any custom [values](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-storage/values.yaml) to the `kof-storage` chart
-    or its subcharts, such as [victoria-logs-single](https://docs.victoriametrics.com/helm/victorialogs-single/index.html#parameters),
+    or its subcharts, such as [victoria-logs-cluster](https://docs.victoriametrics.com/helm/victorialogs-cluster/#parameters),
     add them to the `regional-cluster.yaml` file in the `.spec.config.clusterAnnotations`, for example:
     ```yaml
     k0rdent.mirantis.com/kof-storage-values: |
-      victoria-logs-single:
-        server:
+      victoria-logs-cluster:
+        vlinsert:
           replicaCount: 2
     ```
 
-10. Verify and apply the Regional `ClusterDeployment`:
+11. Verify and apply the Regional `ClusterDeployment`:
     ```shell
     cat regional-cluster.yaml
 
     kubectl apply -f regional-cluster.yaml
     ```
 
-11. Watch how the cluster is deployed until all values of `READY` are `True`:
+12. Watch how the cluster is deployed until all values of `READY` are `True`:
     ```shell
     clusterctl describe cluster -n kcm-system $REGIONAL_CLUSTER_NAME \
       --show-conditions all
@@ -420,7 +426,7 @@ and apply this example for AWS, or use it as a reference:
 
     ```shell
     cat >child-cluster.yaml <<EOF
-    apiVersion: k0rdent.mirantis.com/v1alpha1
+    apiVersion: k0rdent.mirantis.com/v1beta1
     kind: ClusterDeployment
     metadata:
       name: $CHILD_CLUSTER_NAME
@@ -452,7 +458,7 @@ and apply this example for AWS, or use it as a reference:
     echo "AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID"
 
     cat >child-cluster.yaml <<EOF
-    apiVersion: k0rdent.mirantis.com/v1alpha1
+    apiVersion: k0rdent.mirantis.com/v1beta1
     kind: ClusterDeployment
     metadata:
       name: $CHILD_CLUSTER_NAME

--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -371,7 +371,7 @@ and apply this example for AWS, or use it as a reference:
     ```
 
 9. If you need a custom http client configuration for `PromxyServerGroup` and `GrafanaDatasource`,
-    add it to the `regional-cluster.yaml` file in the `.metadata.annotations`, for example:
+    add it to the `regional-cluster.yaml` file in the `.metadata.annotations`. For example:
     ```yaml
     k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "10s", "tls_config": {"insecure_skip_verify": true}}'
     ```
@@ -380,7 +380,7 @@ and apply this example for AWS, or use it as a reference:
     configures and installs `cert-manager`, `ingress-nginx`, `kof-storage`, `kof-operators`, and `kof-collectors` charts automatically.
     To pass any custom [values](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-storage/values.yaml) to the `kof-storage` chart
     or its subcharts, such as [victoria-logs-cluster](https://docs.victoriametrics.com/helm/victorialogs-cluster/#parameters),
-    add them to the `regional-cluster.yaml` file in the `.spec.config.clusterAnnotations`, for example:
+    add them to the `regional-cluster.yaml` file in the `.spec.config.clusterAnnotations`. For example:
     ```yaml
     k0rdent.mirantis.com/kof-storage-values: |
       victoria-logs-cluster:

--- a/docs/admin/kof/kof-maintainence.md
+++ b/docs/admin/kof/kof-maintainence.md
@@ -38,6 +38,8 @@ To remove KOF from the management cluster:
 helm uninstall --wait --cascade foreground -n istio-system kof-istio
 helm uninstall --wait --cascade foreground -n kof kof-child
 helm uninstall --wait --cascade foreground -n kof kof-regional
+helm uninstall --wait --cascade foreground -n kof kof-collectors
+helm uninstall --wait --cascade foreground -n kof kof-storage
 helm uninstall --wait --cascade foreground -n kof kof-mothership
 helm uninstall --wait --cascade foreground -n kof kof-operators
 kubectl delete namespace kof --wait --cascade=foreground

--- a/docs/admin/kof/kof-scaling.md
+++ b/docs/admin/kof/kof-scaling.md
@@ -15,7 +15,7 @@ The method for scaling KOF depends on the type of expansion:
 
 ## You Must Construct Additional Pylons
 
-1. Change the `replicaCount` of components like `victoria-logs-single`
+1. Change the `replicaCount` of components like `victoria-logs-cluster`
     as documented in the [regional cluster](./kof-install.md#regional-cluster) section.
 2. Change the `replicas` number of components like `opencost`
     as documented in the [child cluster](./kof-install.md#child-cluster) section.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -300,14 +300,7 @@ extra:
     k0rdentDigestValue: sha256:14d3f0f36a183759931626886b4742e1c96bf3ecfd8d5d9268ca1ef5db3f553c
     k0rdentDigestDate: Sun May 18 22:44:13 2025
     kofVersions:
-      kofVersion: 0.3.0
-      kofDotVersion: 0.3.0
-      kofStorageVersion: 0.3.0
-      kofDotStorageVersion: 0.3.0
-      kofOperatorsVersion: 0.3.0
-      kofDotOperatorsVersion: 0.3.0
-      kofCollectorsVersion: 0.3.0
-      kofDotCollectorsVersion: 0.3.0
+      kofDotVersion: 1.0.0
     providerVersions:
       dashVersions:
         clusterApi: 0-3-0


### PR DESCRIPTION
Docs update for [kof v1.0.0](https://github.com/k0rdent/kof/releases/tag/v1.0.0):
* Replaced `k0rdent.mirantis.com/v1alpha1` --> `k0rdent.mirantis.com/v1beta1`
* Documented https://github.com/k0rdent/kof/pull/274
* Documented https://github.com/k0rdent/kof/pull/276
* Set kof version to 1.0.0, deleted unused kof version variables.
* Smoke-tested using kcm 1.0.0 and kof 1.0.0 - OK.
