### PR TITLE
Improve k0s install docs for k0rdent

### DIFF
--- a/docs/admin/installation/create-mgmt-clusters/index.md
+++ b/docs/admin/installation/create-mgmt-clusters/index.md
@@ -8,5 +8,6 @@ The type of cluster you create for as a {{{ docsVersionInfo.k0rdentName }}} mana
 In a production environment, you will always want to ensure that your management cluster is backed up. There are a few caveats and things you need to take into account when backing up {{{ docsVersionInfo.k0rdentName }}}. More info can be found in the guide at [use Velero as a backup provider](../../backup/index.md).
 
 - [Create a single node k0s cluster](./mgmt-create-k0s-single.md)
+- [Create a multi-node k0s cluster](./mgmt-create-k0s-multi.md)
 - [Create a multinode EKS cluster](./mgmt-create-eks-multi.md)
   

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
@@ -1,0 +1,123 @@
+# Create and prepare a multinode Kubernetes cluster with k0s
+
+Follow these steps to install and prepare a multinode [k0s kubernetes](https://k0sproject.io) management cluster:
+
+Many features of {{{ docsVersionInfo.k0rdentName }}} require a Kubernetes cluster that uses etcd for its persistence layer. While this is the case for many implementations, the single-node k0s cluster uses SQLite instead. Fortunately, multi-node k0s uses etcd by default, so you can solve this problem by creating controller and worker nodes and linking them together. 
+
+## Create the first controller
+
+1. Download k0s:
+
+    Run the k0s download script to download the latest stable version of k0s and make it executable from `/usr/bin/k0s`:
+
+    ```shell
+    curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+    ```
+
+2. Create a configuration file:
+
+    mkdir -p /etc/k0s
+    k0s config create > /etc/k0s/k0s.yaml
+
+3. If you need to access the cluster from outside the specific node on which you're installing it, add the external address, as in:
+
+    ```yaml
+    spec:
+    api:
+        externalAddress: <your-public-ip>
+        sans:
+        - <your-public-ip>
+    ```
+
+    You can also make other configuration changes accodring to the [documentation](https://docs.k0sproject.io/stable/configuration/).
+
+4. Install the controller:
+
+    ```shell
+    sudo k0s install controller -c /etc/k0s/k0s.yaml
+    sudo k0s start
+    ```
+
+    The k0s process acts as a "supervisor" for all of the control plane components. In moments the control plane will be up and running.
+
+## Add workers to the cluster
+
+1. Create a join token:
+
+    To join additional nodes to the cluster, uou need a join token, which is a base64-encoded `KUBECONFIG`. The token embeds information that enables mutual trust between the worker and controller(s) and allows the node to join the cluster.
+
+    To get a worker token, run the following command on newly created existing controller node:
+
+    ```shell
+    sudo k0s token create --role=worker > token-file
+    ```
+
+    The resulting output is a long token string, which we'll use in a moment to add a worker to the cluster.
+
+    For enhanced security, set an expiration time for the token:
+
+    ```shell
+    sudo k0s token create --role=worker --expiry=100h > token-file
+    ```
+
+2. Add workers to the cluster:
+
+    To join the worker download k0s to the worker node and run it with the join token you created:
+
+    ```shell
+    curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+    sudo k0s install worker --token-file /path/to/token/file/token-file
+    sudo k0s start
+    ```
+
+## Add controllers to the cluster
+
+To create a join token for the new controller, follow these steps.
+
+1. Run the following command on an existing controller:
+
+    ```shell
+    sudo k0s token create --role=controller --expiry=1h > token-file
+    ```
+2. Copy the `token-file` and the `k0s.yaml` file to the new controller. Copy `k0s.yaml` to  `/etc/k0s/k0s.yaml`. Each controller in the cluster must have this `k0s.yaml` file, or some cluster nodes will use default config values, which will lead to inconsistency behavior. If your configuration file includes IP addresses (node address, sans, etcd peerAddress), remember to update them accordingly for this specific controller node.
+
+3. On the new controller, run:
+
+    ```shell
+    sudo k0s install controller --token-file /path/to/token/file -c /etc/k0s/k0s.yaml
+    sudo k0s start
+    ```
+
+4. Check k0s status by running:
+
+    ```shell
+    sudo k0s status
+    ```
+    ```console
+    Version: v1.33.1+k0s.1
+    Process ID: 2769
+    Parent Process ID: 1
+    Role: controller
+    Init System: linux-systemd
+    Service file: /etc/systemd/system/k0scontroller.service
+    ```
+
+## Access your cluster
+
+Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to deploy your application or check your node status:
+
+```shell
+sudo k0s kubectl get nodes
+```
+```console
+NAME   STATUS   ROLES    AGE    VERSION
+k0s    Ready    <none>   4m6s   v1.33.1+k0s
+```
+
+Alternatively, to use a tool like Lens or to access the cluster from another machine, copy the KUBECONFIG, which is located at:
+
+```console
+/var/lib/k0s/pki/admin.conf
+```
+
+to your target machine.  Note that to access the cluster from an external machine you must replace `localhost` in the KUBECONFIG with the host IP address for your controller.

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
@@ -1,8 +1,8 @@
 # Create and prepare a multinode Kubernetes cluster with k0s
 
-Follow these steps to install and prepare a multinode [k0s kubernetes](https://k0sproject.io) management cluster:
-
 Many features of {{{ docsVersionInfo.k0rdentName }}} require a Kubernetes cluster that uses etcd for its persistence layer. While this is the case for many implementations, the single-node k0s cluster uses SQLite instead. Fortunately, multi-node k0s uses etcd by default, so you can solve this problem by creating controller and worker nodes and linking them together. 
+
+Follow these steps to install and prepare a multinode [k0s kubernetes](https://k0sproject.io) management cluster:
 
 ## Create the first controller
 
@@ -16,20 +16,38 @@ Many features of {{{ docsVersionInfo.k0rdentName }}} require a Kubernetes cluste
 
 2. Create a configuration file:
 
+    > NOTE:
+    > Depending on your configuration, you may need to execute these commands as root rather than using `sudo`. If so, executing `sudo su` will be sufficient. Don't forget to exit the root user afterwards!
+
+    ```shell
     mkdir -p /etc/k0s
     k0s config create > /etc/k0s/k0s.yaml
-
-3. If you need to access the cluster from outside the specific node on which you're installing it, add the external address, as in:
-
-    ```yaml
-    spec:
-    api:
-        externalAddress: <your-public-ip>
-        sans:
-        - <your-public-ip>
     ```
 
-    You can also make other configuration changes accodring to the [documentation](https://docs.k0sproject.io/stable/configuration/).
+3. If you need to access the cluster from outside the specific node on which you're installing it, add the public hostname as the `spec.api.externalAddress` and as an instance under `spec.api.sans`, as in:
+
+    ```yaml
+    ...
+    spec:
+        api:
+            address: 172.31.7.199
+            externalAddress: myhost.example.com
+            ca:
+            certificatesExpireAfter: 8760h0m0s
+            expiresAfter: 87600h0m0s
+            k0sApiPort: 9443
+            port: 6443
+            sans:
+            - 172.31.7.199
+            - fe80::c4:e6ff:fecc:9739
+            - myhost.example.com
+        controllerManager: {}
+        extensions:
+            helm:
+    ...
+    ```
+
+    You can also make other configuration changes. For more information see the [k0s documentation](https://docs.k0sproject.io/stable/configuration/).
 
 4. Install the controller:
 
@@ -38,13 +56,27 @@ Many features of {{{ docsVersionInfo.k0rdentName }}} require a Kubernetes cluste
     sudo k0s start
     ```
 
-    The k0s process acts as a "supervisor" for all of the control plane components. In moments the control plane will be up and running.
+    The k0s process acts as a "supervisor" for all of the control plane components. In moments the control plane will be up and running, but because of the k0s architecture, you won't see any nodes running, because only worker nodes show up, and we haven't created any yet. You can, however, use the k0s-installed `kubectl` to make sure the cluster is up and running by looking for existing namespaces:
+
+    ```shell
+    sudo k0s kubectl get namespaces
+    ```
+    ```console
+    NAME              STATUS   AGE
+    default           Active   5m15s
+    k0s-autopilot     Active   5m11s
+    kube-node-lease   Active   5m15s
+    kube-public       Active   5m15s
+    kube-system       Active   5m15s
+    ```
 
 ## Add workers to the cluster
 
+Once the contoller is up, you can add a worker node by creating a "join token" and using it to start k0s on a new server. Follow these instructions:
+
 1. Create a join token:
 
-    To join additional nodes to the cluster, uou need a join token, which is a base64-encoded `KUBECONFIG`. The token embeds information that enables mutual trust between the worker and controller(s) and allows the node to join the cluster.
+    To join additional nodes to the cluster, you need a join token, which is a base64-encoded `KUBECONFIG`. The token embeds information that enables mutual trust between the worker and controller(s) and allows the node to join the cluster.
 
     To get a worker token, run the following command on newly created existing controller node:
 
@@ -60,26 +92,62 @@ Many features of {{{ docsVersionInfo.k0rdentName }}} require a Kubernetes cluste
     sudo k0s token create --role=worker --expiry=100h > token-file
     ```
 
-2. Add workers to the cluster:
+2. Create the new node:
 
-    To join the worker download k0s to the worker node and run it with the join token you created:
+    Start by instantiating the new node and downloading k0s, as before:
 
     ```shell
     curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+    ```
+
+3. Copy the token file you created in step 1 to the new server.
+
+4. Start the new worker: 
+
+    Now you can start the new worker, feeding it the token file so that it automatically joins the existing cluster:
+
+    > NOTE:
+    > Don't forget to use the actual path to your token file.
+
+    ```shell
     sudo k0s install worker --token-file /path/to/token/file/token-file
     sudo k0s start
+    ```
+
+5. Check the node status:
+
+    Now you can check the status of the node by going **to the controller** and once again checking for nodes. After a minute or two, you'll see the new node in a `Ready` state:
+
+    ```shell
+    sudo k0s kubectl get nodes
+    ```
+    ```console
+    NAME              STATUS     ROLES    AGE     VERSION
+    ip-172-31-9-107   Ready      <none>   3m39s   v1.33.1+k0s
     ```
 
 ## Add controllers to the cluster
 
 To create a join token for the new controller, follow these steps.
 
-1. Run the following command on an existing controller:
+
+1. Copy the `k0s.yaml` file to the new controller server at `/etc/k0s/k0s.yaml`. Each controller in the cluster must have this `k0s.yaml` file, or some cluster nodes will use default config values, which will lead to inconsistent behavior. 
+
+    If your configuration file includes IP addresses (node address, sans, etcd peerAddress), remember to update them accordingly for this specific controller node.
+
+2. Run the following command on an existing controller:
 
     ```shell
-    sudo k0s token create --role=controller --expiry=1h > token-file
+    sudo k0s token create --role=controller --expiry=1h > controller-token-file
     ```
-2. Copy the `token-file` and the `k0s.yaml` file to the new controller. Copy `k0s.yaml` to  `/etc/k0s/k0s.yaml`. Each controller in the cluster must have this `k0s.yaml` file, or some cluster nodes will use default config values, which will lead to inconsistency behavior. If your configuration file includes IP addresses (node address, sans, etcd peerAddress), remember to update them accordingly for this specific controller node.
+
+    Copy the `controller-token-file` file to the new controller server.
+
+4. As before, download and install k0s in the new controller:
+
+    ```shell
+    curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+    ```
 
 3. On the new controller, run:
 
@@ -88,18 +156,17 @@ To create a join token for the new controller, follow these steps.
     sudo k0s start
     ```
 
-4. Check k0s status by running:
+4. This time, check k0s status by running this command on the new controller:
 
     ```shell
     sudo k0s status
     ```
     ```console
     Version: v1.33.1+k0s.1
-    Process ID: 2769
-    Parent Process ID: 1
+    Process ID: 1489
     Role: controller
-    Init System: linux-systemd
-    Service file: /etc/systemd/system/k0scontroller.service
+    Workloads: false
+    SingleNode: false
     ```
 
 ## Access your cluster
@@ -114,10 +181,23 @@ NAME   STATUS   ROLES    AGE    VERSION
 k0s    Ready    <none>   4m6s   v1.33.1+k0s
 ```
 
-Alternatively, to use a tool like Lens or to access the cluster from another machine, copy the KUBECONFIG, which is located at:
+You can also install `kubectl` directly. You can find the [full install docs here](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/), or just follow these instructions:
+
+```shell
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # allow unprivileged APT programs to read this keyring
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # helps tools such as command-not-found to work correctly
+sudo apt-get update
+sudo apt-get install -y kubectl
+```
+
+To use `kubectl` directly or to access the cluster from another machine, copy the `KUBECONFIG`, which is located on the controllers at:
 
 ```console
 /var/lib/k0s/pki/admin.conf
 ```
 
-to your target machine.  Note that to access the cluster from an external machine you must replace `localhost` in the KUBECONFIG with the host IP address for your controller.
+to your target machine.  Note that to access the cluster from an external machine you must replace `localhost` in the `KUBECONFIG` with the host IP address or hostname for your controller. Make sure to use the address you added to the `sans` field, and also that port `6443` is accessible.

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-single.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-single.md
@@ -6,7 +6,7 @@ Follow these steps to install and prepare a [k0s kubernetes](https://k0sproject.
 
     The first step is to create the actual cluster itself. Again, the actual distribution used for the management cluster isn't important, as long as it's a CNCF-compliant distribution. That means you can use an existing EKS cluster, or whatever is your normal corporate standard. 
 
-    To make things simple this guide uses [k0s](https://github.com/k0sproject/k0s/), a small, convenient, and fully-functional distribution:
+    To make things simple this guide uses [k0s](https://github.com/k0sproject/k0s/), a small, convenient, and fully-functional distribution. For more granular instructions, including those for creating a cluster accessible from a different server, see the [k0s multi-node instructions](mgmt-create-k0s-multi.md):
 
     ```shell
     curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
@@ -79,3 +79,12 @@ Follow these steps to install and prepare a [k0s kubernetes](https://k0sproject.
 
     Helm will be installed into `/usr/local/bin/helm`.
 
+## Access your cluster from another machine
+
+To use a tool like Lens or to access the cluster from another machine, copy the `KUBECONFIG`, which is located at:
+
+```console
+/var/lib/k0s/pki/admin.conf
+```
+
+to your target machine.  Note that to access the cluster from an external machine you must replace `localhost` in the `KUBECONFIG` with the host IP address or hostname for your controller. Make sure to use the address you added to the `sans` field, and also that port `6443` is accessible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Creating the management cluster:
         - Overview: admin/installation/create-mgmt-clusters/index.md
         - Create a single node k0s cluster: admin/installation/create-mgmt-clusters/mgmt-create-k0s-single.md
+        - Create a multi-node k0s cluster: admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
         - Create a multinode EKS cluster: admin/installation/create-mgmt-clusters/mgmt-create-eks-multi.md
       - Install k0rdent: admin/installation/install-k0rdent.md
       - Verify the k0rdent installation: admin/installation/verify-install.md


### PR DESCRIPTION
Includes instructions for:

1) Creating a multi-node k0s cluster, which uses etcd by default
2) Configuring the cluster to be accessible from outside the controller