### PR TITLE
fix: gap in docs related to ServiceTemplateChain and services upgrade

### DIFF
--- a/docs/user/services/index.md
+++ b/docs/user/services/index.md
@@ -10,3 +10,4 @@ You can find numerous useful applications in the [k0rdent Catalog](https://catal
 - [Checking Status](checking-status.md)
 - [Remove Beach Head Services](remove-beach-head.md)
 - [ServiceTemplate Parameters](servicetemplate-parameters.md)
+- [Service Upgrades with ServiceTemplateChain](service-upgrade.md)

--- a/docs/user/services/index.md
+++ b/docs/user/services/index.md
@@ -10,4 +10,4 @@ You can find numerous useful applications in the [k0rdent Catalog](https://catal
 - [Checking Status](checking-status.md)
 - [Remove Beach Head Services](remove-beach-head.md)
 - [ServiceTemplate Parameters](servicetemplate-parameters.md)
-- [Service Upgrades with ServiceTemplateChain](service-upgrade.md)
+- [Service Upgrades and ServiceTemplateChain](service-upgrade.md)

--- a/docs/user/services/service-upgrade.md
+++ b/docs/user/services/service-upgrade.md
@@ -1,0 +1,124 @@
+# Upgrading and rolling back deployed services
+
+## Service Version Upgrade
+
+When you deploy a service to a cluster, you can specify a `ServiceTemplateChain` which will be used to define available upgrade path for the service. 
+
+> INFO:
+> Before you begin, make sure all templates, you're going to add to `ServiceTemplateChain`, exist in system namespace.
+> Templates can be propagated to other namespaces using [Template Life Cycle Management](../../reference/template/index.md).
+
+First, you need to create a `ServiceTemplateChain` object:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplateChain
+metadata:
+  name: ingress-nginx-chain
+  namespace: kcm-system
+spec:
+  supportedTemplates:
+    - name: ingress-nginx-4-11-3
+      availableUpgrades:
+      - name: ingress-nginx-4-11-5
+    - name: ingress-nginx-4-11-5
+```
+
+This object defines a chain of templates that can be used to upgrade the service.
+
+> WARNING:
+> The `ServiceTemplateChain` has immutable spec. You can't change it after it's created.
+
+After `ServiceTemplateChain` is created you can use it in `ClusterDeployment` or `MutliClusterService` object to define available upgrade path for the service:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: my-cluster-deployment
+  namespace: tenant42
+spec:
+  config:
+    clusterLabels: {}
+  template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
+  credential: aws-credential
+  serviceSpec:
+    services:
+      - template: ingress-nginx-4-11-3
+        templateChain: ingress-nginx-chain
+        name: ingress-nginx
+        namespace: tenant42
+    priority: 100
+```
+
+> WARNING:
+> If no `templateChain` is specified for the service, the service upgrade will be unavailable.
+> You'll observe the following error message in the logs:
+> `service ingress-nginx/ingress-nginx can't be upgraded from ingress-nginx-4-11-3 to ingress-nginx-4-11-5`
+> in case you'll try to change the service template.
+
+After `ClusterDeployment` or `MultiClusterService` will be reconciled, you can observe available upgrade paths for the service in the status:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: my-cluster-deployment
+  namespace: tenant42
+spec:
+  ...
+status:
+  servicesUpgradePaths:
+    - availableUpgrades:
+        - upgradePaths:
+            - ingress-nginx-4-11-5
+      name: ingress-nginx
+      namespace: ingress-nginx
+      template: ingress-nginx-4-11-3
+```
+
+Now you can update the `ClusterDeployment` or `MultiClusterService` object to upgrade the service to the available version:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: my-cluster-deployment
+  namespace: tenant42
+spec:
+  config:
+    clusterLabels: {}
+  template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
+  credential: aws-credential
+  serviceSpec:
+    services:
+      - template: ingress-nginx-4-11-5 # <-- upgrade to the latest version
+        templateChain: ingress-nginx-chain
+        name: ingress-nginx
+        namespace: tenant42
+    priority: 100
+```
+
+## Service Version Rollback
+
+In general, the process of upgrading a service is the same as the process of rolling back to the previous version. You'll need to create separate `ServiceTemplateChain` which defines the reversed upgrade path:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplateChain
+metadata:
+  name: ingress-nginx-chain
+  namespace: kcm-system
+spec:
+  supportedTemplates:
+    - name: ingress-nginx-4-11-3
+    - name: ingress-nginx-4-11-5
+      availableUpgrades:
+        - name: ingress-nginx-4-11-3
+```
+
+After `ServiceTemplateChain` is created you can use it in `ClusterDeployment` or `MutliClusterService` object to define available rollback path for the service:
+
+1. update the `ClusterDeployment` or `MultiClusterService` object with rollback `ServiceTempalteChain`
+2. wait for the `ClusterDeployment` or `MultiClusterService` to be reconciled
+3. update the `ClusterDeployment` or `MultiClusterService` object with the previous version of the service

--- a/docs/user/services/service-upgrade.md
+++ b/docs/user/services/service-upgrade.md
@@ -2,10 +2,10 @@
 
 ## Service Version Upgrade
 
-When you deploy a service to a cluster, you can specify a `ServiceTemplateChain` which will be used to define available upgrade path for the service. 
+When you deploy a service to a cluster, you can specify a `ServiceTemplateChain` that will be used to define available upgrade path for the service. 
 
 > INFO:
-> Before you begin, make sure all templates, you're going to add to `ServiceTemplateChain`, exist in system namespace.
+> Before you begin, make sure all templates you're going to add to `ServiceTemplateChain` exist in system namespace (normally `kcm-system`).
 > Templates can be propagated to other namespaces using [Template Life Cycle Management](../../reference/template/index.md).
 
 First, you need to create a `ServiceTemplateChain` object:
@@ -29,7 +29,7 @@ This object defines a chain of templates that can be used to upgrade the service
 > WARNING:
 > The `ServiceTemplateChain` has immutable spec. You can't change it after it's created.
 
-After `ServiceTemplateChain` is created you can use it in `ClusterDeployment` or `MutliClusterService` object to define available upgrade path for the service:
+After `ServiceTemplateChain` is created, you can use it in `ClusterDeployment` or `MutliClusterService` objects to define the available upgrade path for the service:
 
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1beta1
@@ -52,12 +52,14 @@ spec:
 ```
 
 > WARNING:
-> If no `templateChain` is specified for the service, the service upgrade will be unavailable.
-> You'll observe the following error message in the logs:
-> `service ingress-nginx/ingress-nginx can't be upgraded from ingress-nginx-4-11-3 to ingress-nginx-4-11-5`
-> in case you'll try to change the service template.
+> If no `templateChain` is specified for the service, the service cannot be upgraded because no path is availble.
+> If you try to change the service template, in the logs, you'll see an error message such as:
+>
+> ```shell
+> service ingress-nginx/ingress-nginx can't be upgraded from ingress-nginx-4-11-3 to ingress-nginx-4-11-5
+> ```
 
-After `ClusterDeployment` or `MultiClusterService` will be reconciled, you can observe available upgrade paths for the service in the status:
+After the `ClusterDeployment` or `MultiClusterService` has been reconciled, you will see available upgrade paths for the service in the status:
 
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1beta1
@@ -101,7 +103,7 @@ spec:
 
 ## Service Version Rollback
 
-In general, the process of upgrading a service is the same as the process of rolling back to the previous version. You'll need to create separate `ServiceTemplateChain` which defines the reversed upgrade path:
+In general, the process of rolling back a service to the previous version is the same as upgrading the service in the first place. You'll need to create a separate `ServiceTemplateChain`, which defines the downgrade path:
 
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1alpha1
@@ -117,8 +119,8 @@ spec:
         - name: ingress-nginx-4-11-3
 ```
 
-After `ServiceTemplateChain` is created you can use it in `ClusterDeployment` or `MutliClusterService` object to define available rollback path for the service:
+After the `ServiceTemplateChain` has been created, you can use it in a `ClusterDeployment` or `MutliClusterService` object to define the available rollback path for the service. Follow these steps:
 
-1. update the `ClusterDeployment` or `MultiClusterService` object with rollback `ServiceTempalteChain`
-2. wait for the `ClusterDeployment` or `MultiClusterService` to be reconciled
-3. update the `ClusterDeployment` or `MultiClusterService` object with the previous version of the service
+1. Update the `ClusterDeployment` or `MultiClusterService` object with the rollback `ServiceTemplateChain`.
+2. Wait for the `ClusterDeployment` or `MultiClusterService` to be reconciled.
+3. Update the `ClusterDeployment` or `MultiClusterService` object with the previous version of the service.


### PR DESCRIPTION
This PR adds missing description of services' upgrade process using `ServiceTemplateChain`