### PR TITLE
Custom CA support instruction

### DIFF
--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -115,7 +115,7 @@ Controller Manager and to download required images, such as `etcd` or `kube-prox
 registry (optional). This `Secret` should exist in the system namespace (default: `kcm-system`).
 
 Additionally, if your registry is private and uses a certificate signed by an unknown authority, you can make the
-registry trusted within the K0rdent system by configuring the `registryCertSecret` parameter. This should reference
+registry "trusted" within the K0rdent system by configuring the `registryCertSecret` parameter. This should reference
 the name of a `Secret` in the system (default: `kcm-system`) namespace containing a client certificate (`tls.crt`)
 and a private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the registry endpoint.
 
@@ -211,8 +211,8 @@ spec:
 ### Configuring a global K0s URL
 
 You can override the default URL from which to download the k0s binary in {{{ docsVersionInfo.k0rdentName }}} by
-specifying the `globalK0sURL` and optionally `k0sURLCertSecret` (if the k0s download URL is private and uses a
-certificate signed by an unknown authority) under `spec.core.kcm.config.controller`. This is optional and is only
+specifying the `globalK0sURL`, and optionally `k0sURLCertSecret` (if the k0s download URL is private and uses a
+certificate signed by an unknown authority), under `spec.core.kcm.config.controller`. This is optional and is only
 needed when the environment does not have access to the default upstream k0s binaries endpoint. This is required for
 airgapped environments.
 
@@ -286,7 +286,7 @@ spec:
 
 ### Configuring manager settings for CAPI providers
 
-Starting from k0rdent `v0.3.0`, configuring manager settings for CAPI providers is supported. You can override
+Starting from `v0.3.0`, k0rdent supports configuring manager settings for CAPI providers. You can override
 these settings by defining the `spec.providers[*].config.manager` section. The values under the `manager` section should
 follow the format described here:
 https://github.com/kubernetes-sigs/cluster-api-operator/blob/v0.18.1/api/v1alpha2/provider_types.go#L126.

--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -60,7 +60,7 @@ There are two options to override the default management configuration of {{{ do
                kcm:
                  config:
                    controller:
-                     defaultRegistryURL: "oci://ghcr.io/my-oci-registry-name/kcm/charts"
+                     templatesRepoURL: "oci://ghcr.io/my-oci-registry-name/kcm/charts"
              providers:
              - name: k0smotron
              - name: cluster-api-provider-aws
@@ -102,14 +102,26 @@ and may include the `template` and `config` fields:
 ```
 ## Examples and Use Cases
 ### Configuring a Custom OCI Registry for KCM components
-You can override the default registry settings in {{{ docsVersionInfo.k0rdentName }}} by specifying the `defaultRegistryURL`, `insecureRegistry`,
-and `registryCredsSecret` parameters under `spec.core.kcm.config.controller`:
+You can override the default registry settings in {{{ docsVersionInfo.k0rdentName }}} by specifying the `templatesRepoURL`, `insecureRegistry`,
+and `registryCredsSecret` parameters under `spec.core.kcm.config.controller`.
 
-* `defaultRegistryURL`: Specifies the registry URL for downloading Helm charts representing templates. 
+* `templatesRepoURL`: Specifies the registry URL for downloading Helm charts representing templates.
 Use the `oci://` prefix for OCI registries. Default: `oci://ghcr.io/k0rdent/kcm/charts`.
+* `globalRegistry`: Specifies the global registry. This value will be propagated to all `ClusterDeployment` objects
+configuration as `global.registry` (for example, it is used for pulling cluster Helm extensions, such as the Cloud
+Controller Manager and to download required images, such as `etcd` or `kube-proxy`).
 * `insecureRegistry`: Allows connecting to an HTTP registry. Default: `false`.
 * `registryCredsSecret`: Specifies the name of a Kubernetes Secret containing authentication credentials for the 
 registry (optional). This Secret should exist in the system namespace (default: `kcm-system`).
+
+Additionally, if your registry is private and uses a certificate signed by an unknown authority, you can make the
+registry trusted within the K0rdent system by configuring the `registryCertSecret` parameter. This should reference
+the name of a Secret in the system (default: `kcm-system`) namespace containing a client certificate (`tls.crt`)
+and a private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the registry endpoint.
+
+> NOTE:
+> If you’re using a private registry signed by an unknown certificate authority, refer to
+> [Private Secure Registry Usage](private-secure-registry.md) for the required prerequisites.
 
 Example Configuration:
 
@@ -119,10 +131,16 @@ spec:
     kcm:
       config:
         controller:
-          defaultRegistryURL: "oci://ghcr.io/my-private-oci-registry-name/kcm/charts"
-          insecureRegistry: true
+          templatesRepoURL: "oci://ghcr.io/my-private-oci-registry-name/kcm/charts"
+          globalRegistry: ghcr.io/my-private-oci-registry-name
+          insecureRegistry: false
           registryCredsSecret: my-private-oci-registry-creds
+          registryCertSecret: registry-cert
 ```
+
+> NOTE:
+> Prior to K0rdent v0.3.0, the `templatesRepoURL` parameter was named `defaultRegistryURL`.
+> (See: [K0rdent v0.3.0 Release Notes](https://github.com/k0rdent/kcm/releases/tag/v0.3.0)).
 
 Example of a Secret with Registry Credentials:
 
@@ -135,6 +153,35 @@ metadata:
 stringData:
   username: "my-user-123"
   password: "my-password-123"
+```
+
+Example of a Secret with Registry Certificate:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-cert
+  namespace: kcm-system
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfjCCAmagAwIBAgIUV/Ykpp7jzkOdfsZs0wwNZOS9X04wDQYJKoZIhvcNAQEL
+    ...
+    2eVUGBCoHgFcUrkjcZlxvjjdaV5L/Y6mEt6u9mIhsb1M8w==
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCXi08l8qhKxcU2
+    ...
+    oAO9TAlVxIZtwL7XWyB29w==
+    -----END PRIVATE KEY-----
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfjCCAmagAwIBAgIUV/Ykpp7jzkOdfsZs0wwNZOS9X04wDQYJKoZIhvcNAQEL
+    ...
+    2eVUGBCoHgFcUrkjcZlxvjjdaV5L/Y6mEt6u9mIhsb1M8w==
+    -----END CERTIFICATE-----
 ```
 
 The KCM controller will create the default [HelmRepository](https://fluxcd.io/flux/components/source/helmrepositories/)
@@ -150,13 +197,73 @@ metadata:
   name: my-private-oci-registry-name
   namespace: kcm-system
 spec:
-  insecure: true
+  insecure: false
   interval: 10m0s
   provider: generic
   type: oci
   url: oci://ghcr.io/my-private-oci-registry-name/kcm/charts
   secretRef:
     name: my-private-oci-registry-creds
+  certSecretRef:
+    name: registry-cert
+```
+
+### Configuring a global K0s URL
+
+You can override the default URL from which to download the k0s binary in {{{ docsVersionInfo.k0rdentName }}} by
+specifying the `globalK0sURL` and optionally `k0sURLCertSecret` (if the k0s download URL is private and uses a
+certificate signed by an unknown authority) under `spec.core.kcm.config.controller`. This is optional and is only
+needed when the environment does not have access to the default upstream k0s binaries endpoint. This is required for
+airgapped environments.
+
+* `globalK0sURL`: Specifies the prefix of the k0s URL from which to download the k0s binary. This value will be
+propagated to all `ClusterDeployment` objects configuration as `global.k0sURL`.
+* `k0sURLCertSecret`: The name of the secret in the system (default: `kcm-system`) namespace containing a client
+certificate (`tls.crt`) and a private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the k0s download URL.
+
+> NOTE:
+> If you’re using a private registry signed by an unknown certificate authority, refer to
+> [Private Secure Registry Usage](private-secure-registry.md) for the required prerequisites.
+
+Example Configuration:
+
+```yaml
+spec:
+  core:
+    kcm:
+      config:
+        controller:
+          globalK0sURL: https://172.19.123.4:8443
+          k0sURLCertSecret: k0s-url-cert
+```
+
+Example of a Secret with K0s URL Certificate:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k0s-url-cert
+  namespace: kcm-system
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfjCCAmagAwIBAgIUV/Ykpp7jzkOdfsZs0wwNZOS9X04wDQYJKoZIhvcNAQEL
+    ...
+    2eVUGBCoHgFcUrkjcZlxvjjdaV5L/Y6mEt6u9mIhsb1M8w==
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCXi08l8qhKxcU2
+    ...
+    oAO9TAlVxIZtwL7XWyB29w==
+    -----END PRIVATE KEY-----
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfjCCAmagAwIBAgIUV/Ykpp7jzkOdfsZs0wwNZOS9X04wDQYJKoZIhvcNAQEL
+    ...
+    2eVUGBCoHgFcUrkjcZlxvjjdaV5L/Y6mEt6u9mIhsb1M8w==
+    -----END CERTIFICATE-----
 ```
 
 ### Configuring a Custom Image for KCM controllers

--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -286,7 +286,7 @@ spec:
 
 ### Configuring manager settings for CAPI providers
 
-Starting from `v0.3.0`, k0rdent supports configuring manager settings for CAPI providers. You can override
+Starting from `v0.3.0`, {{{ docsVersionInfo.k0rdentName }}} supports configuring manager settings for CAPI providers. You can override
 these settings by defining the `spec.providers[*].config.manager` section. The values under the `manager` section should
 follow the format described here:
 https://github.com/kubernetes-sigs/cluster-api-operator/blob/v0.18.1/api/v1alpha2/provider_types.go#L126.

--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -111,12 +111,12 @@ Use the `oci://` prefix for OCI registries. Default: `oci://ghcr.io/k0rdent/kcm/
 configuration as `global.registry` (for example, it is used for pulling cluster Helm extensions, such as the Cloud
 Controller Manager and to download required images, such as `etcd` or `kube-proxy`).
 * `insecureRegistry`: Allows connecting to an HTTP registry. Default: `false`.
-* `registryCredsSecret`: Specifies the name of a Kubernetes Secret containing authentication credentials for the 
-registry (optional). This Secret should exist in the system namespace (default: `kcm-system`).
+* `registryCredsSecret`: Specifies the name of a Kubernetes `Secret` containing authentication credentials for the 
+registry (optional). This `Secret` should exist in the system namespace (default: `kcm-system`).
 
 Additionally, if your registry is private and uses a certificate signed by an unknown authority, you can make the
 registry trusted within the K0rdent system by configuring the `registryCertSecret` parameter. This should reference
-the name of a Secret in the system (default: `kcm-system`) namespace containing a client certificate (`tls.crt`)
+the name of a `Secret` in the system (default: `kcm-system`) namespace containing a client certificate (`tls.crt`)
 and a private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the registry endpoint.
 
 > NOTE:
@@ -142,7 +142,7 @@ spec:
 > Prior to K0rdent v0.3.0, the `templatesRepoURL` parameter was named `defaultRegistryURL`.
 > (See: [K0rdent v0.3.0 Release Notes](https://github.com/k0rdent/kcm/releases/tag/v0.3.0)).
 
-Example of a Secret with Registry Credentials:
+Example of a `Secret` with Registry Credentials:
 
 ```yaml
 apiVersion: v1
@@ -155,7 +155,7 @@ stringData:
   password: "my-password-123"
 ```
 
-Example of a Secret with Registry Certificate:
+Example of a `Secret` with Registry Certificate:
 
 ```yaml
 apiVersion: v1
@@ -237,7 +237,7 @@ spec:
           k0sURLCertSecret: k0s-url-cert
 ```
 
-Example of a Secret with K0s URL Certificate:
+Example of a `Secret` with K0s URL Certificate:
 
 ```yaml
 apiVersion: v1

--- a/docs/appendix/index.md
+++ b/docs/appendix/index.md
@@ -1,7 +1,7 @@
 # Appendix
 
 - [Extended management configuration](appendix-extend-mgmt.md)
-- [Using a Private Secure Registry to deploy K0rdent](private-secure-registry.md)
+- [Using a Private Secure Registry to deploy k0rdent](private-secure-registry.md)
 - [Understanding the dry run](appendix-dryrun.md)
 - [Cloud provider credentials management in CAPI](appendix-providers.md)
 - [Glossary](glossary.md)

--- a/docs/appendix/index.md
+++ b/docs/appendix/index.md
@@ -1,6 +1,7 @@
 # Appendix
 
 - [Extended management configuration](appendix-extend-mgmt.md)
+- [Using a Private Secure Registry to deploy K0rdent](private-secure-registry.md)
 - [Understanding the dry run](appendix-dryrun.md)
 - [Cloud provider credentials management in CAPI](appendix-providers.md)
 - [Glossary](glossary.md)

--- a/docs/appendix/private-secure-registry.md
+++ b/docs/appendix/private-secure-registry.md
@@ -1,0 +1,58 @@
+# Using a Private Secure Registry to deploy K0rdent
+
+## Prerequisites
+
+If you are deploying K0rdent with registry overrides (see
+[Configuring a Custom OCI Registry for KCM components](appendix-extend-mgmt.md#configuring-a-custom-oci-registry-for-kcm-components)),
+and your registry endpoint is secured with a certificate signed by an unknown Certificate Authority (CA), you must
+ensure that the CA certificate is trusted by your management cluster nodes before deploying K0rdent.
+
+To do this, add the CA certificate to the system’s trust store on each management cluster node.
+
+### For Management Clusters Running on k0s
+
+Before starting the k0s controller, do the following:
+
+1. Copy the CA certificate file (e.g., `<PATH_TO_CA_CERT>`) to the system’s trusted certificate directory:
+
+    ```bash
+    sudo cp <PATH_TO_CA_CERT> /usr/local/share/ca-certificates/
+    ```
+
+2. Update the system’s trusted certificates:
+
+    ```bash
+    sudo update-ca-certificates
+    ```
+
+3. Proceed to install k0s as usual
+
+### For Management Clusters Running on Kind
+
+1. Create a Kind configuration file that mounts the CA certificate into the container nodes.
+Suppose your CA certificate is located at `<PATH_TO_CA_CERT>` on your host.
+
+    ```yaml
+    # kind-config.yaml
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+      - role: control-plane
+        extraMounts:
+          - hostPath: <PATH_TO_CA_CERT>
+            containerPath: /usr/local/share/ca-certificates/registry-ca.crt
+    ```
+
+2. Create the Kind cluster using the configuration:
+
+    ```bash
+    kind create cluster --config kind-config.yaml --name <KIND_CLUSTER_NAME>
+    ```
+
+3. Run the following command to update the trust store inside the container. Repeat this command for each node in the
+Kind cluster, replacing `<KIND_CLUSTER_NAME>-control-plane` with the name of the Docker container representing that
+node:
+
+    ```bash
+    docker exec <KIND_CLUSTER_NAME>-control-plane update-ca-certificates
+    ```

--- a/docs/appendix/private-secure-registry.md
+++ b/docs/appendix/private-secure-registry.md
@@ -1,11 +1,11 @@
-# Using a Private Secure Registry to deploy K0rdent
+# Using a Private Secure Registry to deploy {{{ docsVersionInfo.k0rdentName }}}
 
 ## Prerequisites
 
-If you are deploying K0rdent with registry overrides (see
+If you are deploying {{{ docsVersionInfo.k0rdentName }}} with registry overrides (see
 [Configuring a Custom OCI Registry for KCM components](appendix-extend-mgmt.md#configuring-a-custom-oci-registry-for-kcm-components)),
 and your registry endpoint is secured with a certificate signed by an unknown Certificate Authority (CA), you must
-ensure that the CA certificate is trusted by your management cluster nodes before deploying K0rdent.
+ensure that the CA certificate is trusted by your management cluster nodes before deploying {{{ docsVersionInfo.k0rdentName }}}.
 
 To do this, add the CA certificate to the system’s trust store on each management cluster node.
 
@@ -25,7 +25,7 @@ Before starting the k0s controller, do the following:
     sudo update-ca-certificates
     ```
 
-3. Proceed to install k0s as usual
+3. Proceed to install k0s as usual.
 
 ### For Management Clusters Running on Kind
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,7 +235,7 @@ nav:
     - Overview: appendix/index.md
     - Glossary: appendix/glossary.md
     - Extended management configuration: appendix/appendix-extend-mgmt.md
-    - Using a Private Secure Registry to deploy K0rdent: appendix/private-secure-registry.md
+    - Deploy from a private secure registry: appendix/private-secure-registry.md
     - Understanding the dry run: appendix/appendix-dryrun.md
     - Cloud provider credentials management in CAPI: appendix/appendix-providers.md
   - Release Notes:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,6 +235,7 @@ nav:
     - Overview: appendix/index.md
     - Glossary: appendix/glossary.md
     - Extended management configuration: appendix/appendix-extend-mgmt.md
+    - Using a Private Secure Registry to deploy K0rdent: appendix/private-secure-registry.md
     - Understanding the dry run: appendix/appendix-dryrun.md
     - Cloud provider credentials management in CAPI: appendix/appendix-providers.md
   - Release Notes:


### PR DESCRIPTION
1. Renamed `defaultRegistryURL` to `templatesRepoURL` in the extended management configuration instructions.
2. Added instructions on how to configure the registry certificate secret and the K0s URL certificate secret parameters in K0rdent.
3. Added prerequisites for management clusters running on K0s and Kind when using a private registry signed by an unknown certificate authority.

This feature is available starting from OSS 1.1.0

Fixes https://github.com/k0rdent/kcm/issues/1635