### PR TITLE
docs(templates): new common params

### DIFF
--- a/docs/reference/template/template-aws.md
+++ b/docs/reference/template/template-aws.md
@@ -74,6 +74,17 @@ spec:
 ...
 ```
 
+## Configuring some of k0s, k0smotron parameters
+
+* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
+* `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
+   See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
+* `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
+* `k0smotron.controllerPlaneFlags` <sup>only hosted</sup> (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
+   and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
+   string, such as `--some-flag=argument`.
+
 ## EKS templates
 
 > WARNING:

--- a/docs/reference/template/template-azure.md
+++ b/docs/reference/template/template-azure.md
@@ -60,3 +60,14 @@ Compute Gallery, Azure Marketplace, and so on).
 Detailed information regarding image can be found in [CAPZ documentation](https://capz.sigs.k8s.io/self-managed/custom-images)
 
 By default, the latest official CAPZ Ubuntu based image is used.
+
+## Configuring some of k0s, k0smotron parameters
+
+* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
+* `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
+   See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
+* `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
+* `k0smotron.controllerPlaneFlags` <sup>only hosted</sup> (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
+   and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
+   string, such as `--some-flag=argument`.

--- a/docs/reference/template/template-azure.md
+++ b/docs/reference/template/template-azure.md
@@ -61,9 +61,9 @@ Detailed information regarding image can be found in [CAPZ documentation](https:
 
 By default, the latest official CAPZ Ubuntu based image is used.
 
-## Configuring some of k0s, k0smotron parameters
+## Configuring k0s, k0smotron parameters
 
-* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+* `k0s.arch` (string): Defines the K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
    is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
 * `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
    See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.

--- a/docs/reference/template/template-gcp.md
+++ b/docs/reference/template/template-gcp.md
@@ -43,7 +43,7 @@ The following parameters are available for `controlPlane` (for standalone cluste
 
 * `k0s.version` (string): K0s version.
 * `k0s.api.extraArgs` (object): Map of key-values (strings) for any extra arguments to pass down to the Kubernetes API server process.
-* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+* `k0s.arch` (string): Defines the K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
    is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
 * `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
    See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.

--- a/docs/reference/template/template-gcp.md
+++ b/docs/reference/template/template-gcp.md
@@ -43,6 +43,11 @@ The following parameters are available for `controlPlane` (for standalone cluste
 
 * `k0s.version` (string): K0s version.
 * `k0s.api.extraArgs` (object): Map of key-values (strings) for any extra arguments to pass down to the Kubernetes API server process.
+* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
+* `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
+   See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
+* `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
 
 ### K0smotron Parameters
 
@@ -51,6 +56,9 @@ Available for the hosted cluster template only.
 * `k0smotron.service.type` (string): An ingress method for a service. One of: `ClusterIP`, `NodePort`, `LoadBalancer`. Defaults to: `LoadBalancer`.
 * `k0smotron.service.apiPort` (number): The Kubernetes API port. If empty, K0smotron will pick it automatically.
 * `k0smotron.service.konnectivityPort` (number): The Konnectivity port. If empty, K0smotron will pick it automatically.
+* `k0smotron.controllerPlaneFlags` (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
+   and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
+   string, such as `--some-flag=argument`.
 
 ### Extensions parameters
 

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -57,6 +57,14 @@ If your user doesn't have access to or your cloud doesn't utilize octavia load b
 
 > WARNING: Disabling loadbalancer blocks usage of `LoadBalancer` type services in cluster until one is manually installed.
 
+### Configuring some of k0s, k0smotron parameters
+
+- `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
+- `k0s.cpArgs` (array of strings): A list of extra arguments to be passed to k0s controller.
+   See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
+- `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
+
 ### Example ClusterDeployment
 
 ```yaml

--- a/docs/reference/template/template-remote.md
+++ b/docs/reference/template/template-remote.md
@@ -20,14 +20,14 @@ To deploy a cluster using {{{ docsVersionInfo.k0rdentName}}} on any SSH accessib
 * `machines[].useSudo` (boolean): Whether or not to use sudo for running commands on the remote machine. Example: `false`.
 * `machines[].provisionJob.scpCommand` (string): The command to use for copying files to remote machines. Example: `"scp"`.
 * `machines[].provisionJob.sshCommand` (string): The command to use for connecting to remote machines. Example: `"ssh"`.
-* `machines[].provisionJob.jobSpecTemplate.metadata`: Kubernetes metadata for the provisioning job, such as labels or annotations. See: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata for more information.
-* `machines[].provisionJob.jobSpecTemplate.spec`: Specification for the provisioning job, detailing the job’s behavior and configuration. See: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec for more information.
-* `machines[].k0s.args` (array of strings): A list of extra arguments for configuring the k0s worker node. Example: `["--extra-arg"]`.
+* `machines[].provisionJob.jobSpecTemplate.metadata`: Kubernetes metadata for the provisioning job, such as labels or annotations. See: <https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata> for more information.
+* `machines[].provisionJob.jobSpecTemplate.spec`: Specification for the provisioning job, detailing the job’s behavior and configuration. See: <https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec> for more information.
+* `machines[].k0s.args` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
 
 ### K0smotron Parameters
 
 * `k0smotron.controllerPlaneFlags` (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single string, such as `--some-flag=argument`.
-* `k0smotron.persistence.type` (string): This parameter defines the persistence type for the control plane’s state. Example: `"EmptyDir"`. See https://docs.k0smotron.io/stable/configuration/#persistence for more information.
+* `k0smotron.persistence.type` (string): This parameter defines the persistence type for the control plane’s state. Example: `"EmptyDir"`. See <https://docs.k0smotron.io/stable/configuration/#persistence> for more information.
 * `k0smotron.service.type` (string): This parameter defines the type of service for the Kubernetes API server: `"ClusterIP"`, `"NodePort"`, or `"LoadBalancer"`.
 * `k0smotron.service.apiPort` (number): This parameter defines the port for accessing the Kubernetes API server. Example: `30443`.
 * `k0smotron.service.konnectivityPort` (number): This parameter indicates the port for the Konnectivity service. Example: `30132`.
@@ -35,6 +35,8 @@ To deploy a cluster using {{{ docsVersionInfo.k0rdentName}}} on any SSH accessib
 ### K0s Parameters
 
 * `k0s.version` (string): Specifies the version of the k0s Kubernetes distribution. Example: `"v1.32.2+k0s.0"`.
+* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
 * `k0s.api.extraArgs`: Additional arguments to pass to the Kubernetes API server. Example: `{"--some-arg": "value"}`.
 * `k0s.network`: Network settings for the k0s cluster. Example: `{"dns": "8.8.8.8"}`.
 * `k0s.extensions.helm.repositories` (array of objects): Helm repositories to add during the cluster setup. Example: `[{ "name": "repo1", "url": "https://charts.repo1.com" }]`.

--- a/docs/reference/template/template-vsphere.md
+++ b/docs/reference/template/template-vsphere.md
@@ -57,6 +57,17 @@ govc vm.info -t '*'
 >
 > Minimal `govc` configuration requires setting: `GOVC_URL`, `GOVC_USERNAME`, `GOVC_PASSWORD` environment variables.
 
+### Configuring some of k0s, k0smotron parameters
+
+* `k0s.arch` (string): Defines K0s Arch in its download URL. Available if [global.k0sURL](../../appendix/appendix-extend-mgmt.md#configuring-a-global-k0s-url)
+   is set. Possible values: `"amd64"` (default), `"arm64"`, `"arm"`.
+* `k0s.cpArgs` <sup>only standalone</sup> (array of strings): A list of extra arguments to be passed to k0s controller.
+   See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
+* `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
+* `k0smotron.controllerPlaneFlags` <sup>only hosted</sup> (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
+   and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
+   string, such as `--some-flag=argument`.
+
 ## Example of a ClusterDeployment CR
 
 With all above parameters provided your `ClusterDeployment` can look like this:


### PR DESCRIPTION
Adds new common params for most of the templates
to configure:
- k0s
- k0smotron

Changes:
- `docs/reference/template/template-aws.md`
- `docs/reference/template/template-azure.md`
- `docs/reference/template/template-gcp.md`
- `docs/reference/template/template-openstack.md`
- `docs/reference/template/template-remote.md`
- `docs/reference/template/template-vsphere.md`

Closes #434 