### PR TITLE
docs (ksm): add GitRepository as a source for Helm chart defined in ServiceTemplate

### DIFF
--- a/docs/admin/services/admin-service-templates.md
+++ b/docs/admin/services/admin-service-templates.md
@@ -44,7 +44,7 @@ Helm-based `ServiceTemplate` can be created in three ways:
 - by defining or referring source provided by FluxCD
 
 > NOTE:
-> `ServiceTemplate` can refer existing `HelmChart` object in `.spec.helm.chartRef` field if only `HelmChart` is backed by `HelmRepository` object.
+> `ServiceTemplate` can be defined using `.spec.helm.chartSpec` or `.spec.helm.chartRef` if only Helm chart being defined or referred is backed by `HelmRepository` or `GitRepository` object.
 > To use FluxCD sources, `ServiceTemplate` must be defined using `.spec.helm.chartSource` field.
 
 FluxCD sources supported by `ServiceTemplate` are:
@@ -92,10 +92,10 @@ FluxCD sources supported by `ServiceTemplate` are:
          kind: HelmChart
          name: ingress-nginx-4.11.3
    ```
-   
+
    In this case, we're creating a `ServiceTemplate` called `ingress-nginx-4.11.3` in the
    `my-target-namespace` namespace.  It references the existing `ingress-nginx-4.11.3` Helm chart.
-   
+
 3. Referring existing FluxCD source
 
    ```yaml
@@ -112,11 +112,11 @@ FluxCD sources supported by `ServiceTemplate` are:
            name: k0rdent-catalog
          path: "./charts/ingress-nginx"
    ```
-   
+
    In this case, we're creating a `ServiceTemplate` called `ingress-nginx-4.11.3` in the
-   `my-target-namespace` namespace.  It references the existing `GitRepository` object called 
+   `my-target-namespace` namespace.  It references the existing `GitRepository` object called
    `k0rdent-catalog` and the Helm chart located in the `charts/ingress-nginx` path.
-   
+
 4. Defining Helm chart source, which can be one of types provided by FluxCD:
 
    ```yaml
@@ -136,7 +136,7 @@ FluxCD sources supported by `ServiceTemplate` are:
    ```
 
    In this case, we're creating a `ServiceTemplate` called `ingress-nginx-4.11.3` in the
-   `my-target-namespace` namespace.  It defines the source of the Helm chart located in the 
+   `my-target-namespace` namespace.  It defines the source of the Helm chart located in the
    `s3://bucket/path/to/charts` bucket and path where the Helm chart is located within the bucket.
 
 For more information on creating templates, see the [Template Guide](../../reference/template/index.md).
@@ -195,8 +195,8 @@ When `.spec.kustomize.remoteSourceSpec` is defined, the controller will create c
 
 ### Creating Raw-Resources-based ServiceTemplate
 
-This type of source is quite similar to the kustomization sources, with the only exception: 
-when using `ConfigMap` or `Secret` as a source, the field `.spec.resources.localSourceRef.path` will be ignored 
+This type of source is quite similar to the kustomization sources, with the only exception:
+when using `ConfigMap` or `Secret` as a source, the field `.spec.resources.localSourceRef.path` will be ignored
 and the resources' manifests to be deployed must be inlined in the source's `data`.
 
 Example of the `ConfigMap` and corresponding `ServiceTemplate`:

--- a/docs/reference/template/template-byo.md
+++ b/docs/reference/template/template-byo.md
@@ -76,10 +76,15 @@ For defining the Helm chart, you have three choices. You can either:
 
 1. Specify the actual Helm chart definition in the `.spec.helm.chartSpec` field of the
    [HelmChartSpec](https://fluxcd.io/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.HelmChartSpec) kind,
-2. Reference an existing `HelmChart` object in `.spec.helm.chartRef`, or
+2. Reference an existing `HelmChart` object in `.spec.helm.chartRef`
 
 > NOTE:
-> `spec.helm.chartSpec` and `spec.helm.chartRef` are mutually exclusive.
+> Next option is supported for `ServiceTemplate` objects only
+
+3. Reference FluxCD source of the Helm chart in `.spec.helm.chartSource`
+
+> NOTE:
+> `spec.helm.chartSpec`, `spec.helm.chartRef`, `spec.helm.chartSource` are mutually exclusive.
 
 To automatically create the `HelmChart` for the `Template`, configure the following custom helm chart parameters
 under `spec.helm.chartSpec`:

--- a/docs/user/services/understanding-servicetemplates.md
+++ b/docs/user/services/understanding-servicetemplates.md
@@ -14,6 +14,9 @@ be deployed as a complete application.
 
 ### Helm-based ServiceTemplate
 
+> NOTE:
+> `ServiceTemplate` can be defined using `.spec.helm.chartSpec` or `.spec.helm.chartRef` if only Helm chart being defined or referred is backed by `HelmRepository` or `GitRepository` object.
+
 Helm-based `ServiceTemplate` can be created in three ways:
 
 - by defining Helm chart right in the template object
@@ -34,7 +37,7 @@ Helm-based `ServiceTemplate` can be created in three ways:
           kind: HelmRepository
           name: foo-repository
   ```
-  
+
   In this case the corresponding `HelmChart` object will be created by the controller.
 
 - by referring the existing Helm chart
@@ -74,7 +77,7 @@ Helm-based `ServiceTemplate` can be created in three ways:
           name: foo-repository
         path: "./charts"
   ```
-  
+
   ```yaml
   apiVersion: k0rdent.mirantis.com/v1beta1
   kind: ServiceTemplate
@@ -113,7 +116,7 @@ Kustomize-based `ServiceTemplate` can be created with either local or remote sou
       deploymentType: Remote
       path: "./base"
   ```
-  
+
   `ConfigMap` or `Secret` in this case must embed the tar-gzipped archive containing the kustomization files. This can be done by the following command, assuming the the archive was already created:
 
   ```shell
@@ -139,7 +142,7 @@ Kustomize-based `ServiceTemplate` can be created with either local or remote sou
       deploymentType: Remote
       path: "./overlays"
   ```
-  
+
   `.spec.kustomize.remoteSourceSpec` has mutual exclusive fields `.git`, `.bucket` and `.oci` which inline `GitRepositorySpec`, `BucketSpec` and `OCIRepositorySpec` respectively.
 
 ### Raw-resources-based ServiceTemplate
@@ -148,4 +151,4 @@ Similar to kustomize-based `ServiceTemplate`, raw-resources-based `ServiceTempla
 kustomize-based `ServiceTemplate`, however using local source slightly differ in case `ConfigMap` or `Secret` object is referred as a source:
 
 - `spec.resources.localSourceRef.path` will be ignored
-- referred `ConfigMap` or `Secret` must contain inlined resources' definitions instead of embedding tar-gzipped archive. 
+- referred `ConfigMap` or `Secret` must contain inlined resources' definitions instead of embedding tar-gzipped archive.


### PR DESCRIPTION
Fixes: #437 