### PR TITLE
In Adopting a Cluster, add newline to format the numbered list correctly

### DIFF
--- a/docs/admin/clusters/admin-adopting-clusters.md
+++ b/docs/admin/clusters/admin-adopting-clusters.md
@@ -127,6 +127,7 @@ Follow these steps to adopt an existing cluster:
 ## What's Happening Behind the Scenes?
 
 When you adopt a cluster, {{{ docsVersionInfo.k0rdentName }}} performs several actions:
+
 1. It validates the credentials and configuration provided in the `ClusterDeployment` object.
 2. It ensures network connectivity between the management cluster and the adopted cluster.
 3. It registers the adopted cluster within the {{{ docsVersionInfo.k0rdentName }}} system, enabling it to be monitored and managed like 


### PR DESCRIPTION
On the Adopting clusters page, section [What's Happening Behind the Scenes?](https://docs.k0rdent.io/latest/admin/clusters/admin-adopting-clusters/?h=adopt#adopting-a-cluster), the numbered list was not formatted correctly:

> When you adopt a cluster, k0rdent performs several actions: 1. It validates the credentials and configuration provided in the ClusterDeployment object. 2. It ensures network connectivity between the management cluster and the adopted cluster. 3. It registers the adopted cluster within the k0rdent system, enabling it to be monitored and managed like any k0rdent-deployed cluster.

Adding a newline after the leading sentence corrects this

> When you adopt a cluster, k0rdent performs several actions: 
> 1. It validates the credentials and configuration provided in the ClusterDeployment object. 
> 2. It ensures network connectivity between the management cluster and the adopted cluster. 
> 3. It registers the adopted cluster within the k0rdent system, enabling it to be monitored and managed like any k0rdent-deployed cluster.