### PR TITLE
Add a note about the OpenStack identityRef.name parameter

### DIFF
--- a/docs/admin/hosted-control-plane/hcp-openstack.md
+++ b/docs/admin/hosted-control-plane/hcp-openstack.md
@@ -90,8 +90,8 @@ Follow these steps to set up a k0smotron-hosted control plane on OpenStack:
     > NOTE:
     > When deploying clusters with `openstack-hosted-cp` template version `1-0-2` or newer, the
     > `identityRef.name` parameter is ignored and can be omitted.
-    > For older template versions, this parameter is required and must match the name of the Secret containing the
-    > clouds.yaml configuration.
+    > For older template versions, this parameter is required and must match the name of the `Secret` containing the
+    > `clouds.yaml` configuration.
 
     You can adjust `flavor`, `image name`, `region name`, `network`, `subnet` and `router` configuration to match your
     OpenStack environment.

--- a/docs/admin/hosted-control-plane/hcp-openstack.md
+++ b/docs/admin/hosted-control-plane/hcp-openstack.md
@@ -87,6 +87,12 @@ Follow these steps to set up a k0smotron-hosted control plane on OpenStack:
             name: ${NETWORK_NAME}
     ```
 
+    > NOTE:
+    > When deploying clusters with `openstack-hosted-cp` template version `1-0-2` or newer, the
+    > `identityRef.name` parameter is ignored and can be omitted.
+    > For older template versions, this parameter is required and must match the name of the Secret containing the
+    > clouds.yaml configuration.
+
     You can adjust `flavor`, `image name`, `region name`, `network`, `subnet` and `router` configuration to match your
     OpenStack environment.
     For more information about the configuration options, see the [Template reference for openstack](../../reference/template/template-openstack.md)

--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -238,8 +238,8 @@
     > NOTE:
     > When deploying clusters with `openstack-standalone-cp` template version `1-0-12` or newer, the
     > `identityRef.name` parameter is ignored and can be omitted.
-    > For older template versions, this parameter is required and must match the name of the Secret containing the
-    > clouds.yaml configuration.
+    > For older template versions, this parameter is required and must match the name of the `Secret` containing the
+    > `clouds.yaml` configuration.
 
     You can adjust `flavor`, `image name`, `region name`, and `authURL` to match your OpenStack environment. For more information about the configuration options, see the [OpenStack Template Parameters Reference](../../../reference/template/template-openstack.md).
 

--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -235,6 +235,12 @@
           region: ${OS_REGION_NAME}
     ```
 
+    > NOTE:
+    > When deploying clusters with `openstack-standalone-cp` template version `1-0-12` or newer, the
+    > `identityRef.name` parameter is ignored and can be omitted.
+    > For older template versions, this parameter is required and must match the name of the Secret containing the
+    > clouds.yaml configuration.
+
     You can adjust `flavor`, `image name`, `region name`, and `authURL` to match your OpenStack environment. For more information about the configuration options, see the [OpenStack Template Parameters Reference](../../../reference/template/template-openstack.md).
 
     Apply the YAML to your management cluster:

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -14,6 +14,13 @@ To deploy an OpenStack cluster, the following are the primary parameters in the 
 | `.spec.config.clusterLabels`      | `k0rdent: demo`                       | Labels to apply to the cluster. Used by MultiClusterService.|
 | `.spec.config.ccmRegional`         | `true`                                | Enables the OpenStack CCM OS_CCM_REGIONAL envvar feature and allows OpenStack CCM to define the region in nodes |
 
+> NOTE:
+> When deploying OpenStack clusters with `openstack-standalone-cp` template version 1-0-12
+> or newer or `openstack-hosted-cp` template version 1-0-2 or newer, the `identityRef.name` parameter is ignored and
+> can be omitted.
+> For older template versions, this parameter is required and must match the name of the Secret containing the
+> clouds.yaml configuration.
+
 ### SSH Configuration
 
 To access deployed machines over ssh requires two things:

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -18,8 +18,8 @@ To deploy an OpenStack cluster, the following are the primary parameters in the 
 > When deploying OpenStack clusters with `openstack-standalone-cp` template version 1-0-12
 > or newer or `openstack-hosted-cp` template version 1-0-2 or newer, the `identityRef.name` parameter is ignored and
 > can be omitted.
-> For older template versions, this parameter is required and must match the name of the Secret containing the
-> clouds.yaml configuration.
+> For older template versions, this parameter is required and must match the name of the `Secret` containing the
+> `clouds.yaml` configuration.
 
 ### SSH Configuration
 


### PR DESCRIPTION
This should be included in the documentation starting from:
* OSS v1.2.0
* Enterprise v1.2.0

Related issue https://github.com/k0rdent/kcm/issues/1793