### PR TITLE
Update fix version for manager parameter overrides in K0smotron

### DIFF
--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -287,10 +287,10 @@ Starting from `v0.3.0`, {{{ docsVersionInfo.k0rdentName }}} supports configuring
 these settings by defining the `spec.providers[*].config.manager` section. The values under the `manager` section should
 follow the format defined by the [CAPI Operator](https://pkg.go.dev/sigs.k8s.io/cluster-api-operator/api/v1alpha2#ManagerSpec).
 
-> WARNING: Prior to `v1.1.0` {{{ docsVersionInfo.k0rdentName }}}, this is not supported for the `k0sproject-k0smotron` provider due to a bug in the CAPI Operator:
+> WARNING: Prior to `v1.2.0` {{{ docsVersionInfo.k0rdentName }}}, this is not supported for the `k0sproject-k0smotron` provider due to a bug in the CAPI Operator:
 > [CAPI operator incorrectly finds the manager container if the number of containers is >1](https://github.com/kubernetes-sigs/cluster-api-operator/issues/787).
 >
-> Starting `v1.1.0` {{{ docsVersionInfo.k0rdentName }}} shipped with a CAPI Operator version with [the issue addressed](https://github.com/kubernetes-sigs/cluster-api-operator/pull/796).
+> Starting `v1.2.0` {{{ docsVersionInfo.k0rdentName }}} shipped with a CAPI Operator version with [the issue addressed](https://github.com/kubernetes-sigs/cluster-api-operator/pull/796).
 
 For example, to override feature gates for the Cluster API Provider AWS, configure the following:
 


### PR DESCRIPTION
The issue was resolved in v1.2.0. Although the CAPI operator was bumped in v1.1.0, support for overriding K0smotron manager parameters was introduced only in v1.2.0.

This change can be backported to earlier releases if needed.

Relates task: https://github.com/k0rdent/kcm/pull/1742