### PR TITLE
Document arm64 limitations

### DIFF
--- a/docs/appendix/arm64.md
+++ b/docs/appendix/arm64.md
@@ -1,0 +1,21 @@
+# Running K0rdent on ARM64: Known Limitations
+
+K0rdent can be deployed on ARM64-based infrastructure, but there are some current limitations to be aware of.
+
+## Infoblox CAPI Provider Compatibility
+
+The [Infoblox Cluster API IPAM provider](https://github.com/telekom/cluster-api-ipam-provider-infoblox) does
+**not currently support the ARM64 architecture**. See the upstream issue for
+details: [Multi-arch support](https://github.com/telekom/cluster-api-ipam-provider-infoblox/issues/92).
+
+As a result, the Infoblox provider will fail to start during the installation process, and the
+**management object will remain in a non-ready state**. This blocks the successful deployment of K0rdent on
+ARM64 platforms.
+
+### Workaround
+
+To install K0rdent without the Infoblox provider you should use a **custom management configuration** that excludes
+`cluster-api-provider-infoblox` from the list of enabled providers. Follow the official configuration guide
+here: [Extended Management Configuration Guide](appendix-extend-mgmt.md#configuration-guide).
+
+This will allow K0rdent to be deployed successfully on ARM64 infrastructure without relying on unsupported components.

--- a/docs/appendix/index.md
+++ b/docs/appendix/index.md
@@ -4,4 +4,5 @@
 - [Using a Private Secure Registry to deploy k0rdent](private-secure-registry.md)
 - [Understanding the dry run](appendix-dryrun.md)
 - [Cloud provider credentials management in CAPI](appendix-providers.md)
+- [Running k0rdent on ARM64](arm64.md)
 - [Glossary](glossary.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
     - Deploy from a private secure registry: appendix/private-secure-registry.md
     - Understanding the dry run: appendix/appendix-dryrun.md
     - Cloud provider credentials management in CAPI: appendix/appendix-providers.md
+    - Running k0rdent on ARM64: appendix/arm64.md
   - Release Notes:
     - Overview: release-notes/index.md
     - v1.0.0: release-notes/release-notes-v1.0.0.md


### PR DESCRIPTION
Applies to:
OSS v1.2.0
Enterprise v1.2.0

Deploying on ARM64 should work with older versions as well, although it hasn’t been tested. I suggest adding this note only to the latest versions.

Related task: https://github.com/k0rdent/kcm/issues/1821