### PR TITLE
KOF 1.2.0 docs

### DIFF
--- a/docs/admin/kof/kof-architecture.md
+++ b/docs/admin/kof/kof-architecture.md
@@ -255,12 +255,6 @@ Cloud 1..N
   }
 </style>
 
-## Low-level
-
-At a low level, you can see how metrics, logs, and traces work their way around the system.
-
-![kof-architecture](../../assets/kof/otel.png)
-
 ## Helm Charts
 
 KOF is deployed as a series of Helm charts at various levels.

--- a/docs/admin/kof/kof-maintainence.md
+++ b/docs/admin/kof/kof-maintainence.md
@@ -26,10 +26,6 @@ To remove the demo clusters created in this section:
 ```shell
 kubectl delete --wait --cascade=foreground -f child-cluster.yaml
 kubectl delete --wait --cascade=foreground -f regional-cluster.yaml
-kubectl delete --wait promxyservergroup \
-  -n kof -l app.kubernetes.io/managed-by=kof-operator
-kubectl delete --wait grafanadatasource \
-  -n kof -l app.kubernetes.io/managed-by=kof-operator
 ```
 
 To remove KOF from the management cluster:

--- a/docs/admin/kof/kof-upgrade.md
+++ b/docs/admin/kof/kof-upgrade.md
@@ -1,0 +1,27 @@
+# Upgrading KOF
+
+## Upgrade to v1.2.0
+
+* As part of the KOF 1.2.0 overhaul of metrics collection and representation, we switched from the [victoria-metrics-k8s-stack](https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack) metrics and dashboards to [opentelemetry-kube-stack](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) metrics and [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) dashboards.
+* Some of the previously collected metrics have slightly different labels.
+* If consistency of timeseries labeling is important, users are advised to conduct relabeling of the corresponding timeseries in the metric storage by running a retroactive relabeling procedure of their preference.
+* A possible reference solution here would be to use [Rules backfilling via vmalert](https://victoriametrics.com/blog/rules-replay/).
+* The labels that would require renaming are these:
+    * Replace `job="integrations/kubernetes/kubelet"` with `job="kubelet", metrics_path="/metrics"`.
+    * Replace `job="integrations/kubernetes/cadvisor"` with `job="kubelet", metrics_path="/metrics/cadvisor"`.
+    * Replace `job="prometheus-node-exporter"` with `job="node-exporter"`.
+
+## Upgrade to v1.1.0
+
+* After you `helm upgrade` the `kof-mothership` chart, please run the following:
+    ```shell
+    kubectl apply --server-side --force-conflicts \
+    -f https://github.com/grafana/grafana-operator/releases/download/v5.18.0/crds.yaml
+    ```
+* After you get `regional-kubeconfig` file on the [KOF Verification](./kof-verification.md) step,
+  please run the following for each regional cluster:
+    ```shell
+    KUBECONFIG=regional-kubeconfig kubectl apply --server-side --force-conflicts \
+    -f https://github.com/grafana/grafana-operator/releases/download/v5.18.0/crds.yaml
+    ```
+* This is noted as required in the [grafana-operator release notes](https://github.com/grafana/grafana-operator/releases/tag/v5.18.0).

--- a/docs/admin/kof/kof-verification.md
+++ b/docs/admin/kof/kof-verification.md
@@ -31,17 +31,11 @@ Finally, verify that KOF installed properly.
     KUBECONFIG=child-kubeconfig kubectl get pod -A
     ```
 
-    If you're upgrading from a KOF version less than `1.1.0`, after upgrade please run the following:
-    ```shell
-    KUBECONFIG=regional-kubeconfig kubectl apply --server-side --force-conflicts \
-    -f https://github.com/grafana/grafana-operator/releases/download/v5.18.0/crds.yaml
-    ```
-    This is noted as required in the [grafana-operator release notes](https://github.com/grafana/grafana-operator/releases/tag/v5.18.0).
-
 3. Wait until the value of `READY` changes to `True`
-    for all certificates in the regional cluster:
+    for all certificates in each cluster:
     ```shell
-    KUBECONFIG=regional-kubeconfig kubectl get cert -n kof
+    KUBECONFIG=regional-kubeconfig kubectl get cert -A
+    KUBECONFIG=child-kubeconfig kubectl get cert -A
     ```
 
 ## Manual DNS config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,7 @@ nav:
       - Overview: admin/kof/index.md
       - Architecture: admin/kof/kof-architecture.md
       - Installing KOF: admin/kof/kof-install.md
+      - Upgrading KOF: admin/kof/kof-upgrade.md
       - Verifying the KOF installation: admin/kof/kof-verification.md
       - Storing KOF data: admin/kof/kof-storing.md
       - Using KOF: admin/kof/kof-using.md
@@ -316,7 +317,7 @@ extra:
     k0rdentDigestDate: Wed Jul  2 18:36:23 2025
     k0rdentTagList: https://github.com/k0rdent/kcm/tags
     kofVersions:
-      kofDotVersion: 1.1.0
+      kofDotVersion: 1.2.0
     providerVersions:
       dashVersions:
         clusterApi: 1-0-4


### PR DESCRIPTION
* Closes https://github.com/k0rdent/docs/issues/477
  together with https://github.com/k0rdent/docs/pull/488
* Switch to `opentelemetry-kube-stack` collectors, metrics, dashboards.
* Dedicated "Upgrading KOF" page.
* Option to skip regional `ClusterDeployment`, create regional `ConfigMap` instead.
* Optional `crossNamespace` discovery of regional cluster.
* OpenStack-specific values.
* Istio does not need `REGIONAL_DOMAIN` - never needed, but docs were unclear.
* Auto-deletion of `promxyservergroup` and `grafanadatasource` on uninstall.
* Deleted the outdated "Low-level" diagram.
* Better verification of certs.
