### PR TITLE
Merge pull request #498 from denis-ryzhkov/kof-1-2-0-traces-auth

### DIFF
--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -52,6 +52,8 @@ To apply this option:
 
 2. Create the `collectors-values.yaml` file:
     ```yaml
+    kcm:
+      monitoring: true
     opentelemetry-kube-stack:
       clusterName: mothership
       defaultCRConfig:
@@ -97,6 +99,8 @@ To apply this option:
 1. Create the `collectors-values.yaml` file:
     ```shell
     cat >collectors-values.yaml <<EOF
+    kcm:
+      monitoring: true
     opentelemetry-kube-stack:
       clusterName: mothership
       defaultCRConfig:
@@ -194,6 +198,8 @@ To apply this option:
 1. Create the `collectors-values.yaml` file:
     ```shell
     cat >collectors-values.yaml <<EOF
+    kcm:
+      monitoring: true
     kof:
       basic_auth: false
     opentelemetry-kube-stack:
@@ -263,6 +269,8 @@ For now, however, just for the sake of this demo, you can use the most straightf
 4. Create the `collectors-values.yaml` file:
     ```shell
     cat >collectors-values.yaml <<EOF
+    kcm:
+      monitoring: true
     opentelemetry-kube-stack:
       clusterName: mothership
       defaultCRConfig:

--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -111,6 +111,16 @@ To apply this option:
               secretKeyRef:
                 key: password
                 name: storage-vmuser-credentials
+          - name: KOF_JAEGER_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: jaeger-credentials
+          - name: KOF_JAEGER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: jaeger-credentials
         config:
           processors:
             resource/k8sclustername:
@@ -129,7 +139,11 @@ To apply this option:
             basicauth/logs:
               client_auth:
                 username: ${env:KOF_VM_USER}
-                password: ${env:KOF_VM_PASSWORD}                  
+                password: ${env:KOF_VM_PASSWORD}
+            basicauth/traces:
+              client_auth:
+                username: ${env:KOF_JAEGER_USER}
+                password: ${env:KOF_JAEGER_PASSWORD}
           exporters:
             prometheusremotewrite:
               endpoint: https://vmauth.$REGIONAL_DOMAIN/vm/insert/0/prometheus/api/v1/write
@@ -144,10 +158,13 @@ To apply this option:
                 authenticator: basicauth/logs  
             otlphttp/traces:
               endpoint: https://jaeger.$REGIONAL_DOMAIN/collector
+              auth:
+                authenticator: basicauth/traces
           service:
             extensions:
               - basicauth/metrics
-              - basicauth/logs              
+              - basicauth/logs
+              - basicauth/traces
     opencost:
       opencost:
         prometheus:

--- a/docs/admin/kof/kof-upgrade.md
+++ b/docs/admin/kof/kof-upgrade.md
@@ -11,6 +11,28 @@
     * Replace `job="integrations/kubernetes/cadvisor"` with `job="kubelet", metrics_path="/metrics/cadvisor"`.
     * Replace `job="prometheus-node-exporter"` with `job="node-exporter"`.
 
+Also:
+
+* To upgrade from `cert-manager-1-16-4` to `cert-manager-v1-16-4`
+    please apply this patch to management cluster:
+    ```shell
+    kubectl apply -f - <<EOF
+    apiVersion: k0rdent.mirantis.com/v1beta1
+    kind: ServiceTemplateChain
+    metadata:
+      name: patch-cert-manager-v1-16-4-from-1-16-4
+      namespace: kcm-system
+      annotations:
+        helm.sh/resource-policy: keep
+    spec:
+      supportedTemplates:
+        - name: cert-manager-v1-16-4
+        - name: cert-manager-1-16-4
+          availableUpgrades:
+            - name: cert-manager-v1-16-4
+    EOF
+    ```
+
 ## Upgrade to v1.1.0
 
 * After you `helm upgrade` the `kof-mothership` chart, please run the following:


### PR DESCRIPTION
fix: Jaeger endpoint auth in "From Management to Regional" case of "Storing KOF data"

Move changes to release-v1.2.0