### PR TITLE
Add details about the `managementClusterName` parameter for aws hcp

### DIFF
--- a/docs/admin/hosted-control-plane/hcp-aws.md
+++ b/docs/admin/hosted-control-plane/hcp-aws.md
@@ -95,10 +95,11 @@ Follow these steps to set up a k0smotron-hosted control plane on AWS:
     > NOTE:  
     > The example above uses the `us-west-1` region, but you should use the region of your VPC.
 
-4. Generate the `ClusterDeployment` Manifest
+    Alternatively, you can generate the `ClusterDeployment` manifest.
 
-    To simplify the creation of a `ClusterDeployment` manifest, you can use the following template, which dynamically
-    inserts the appropriate values:
+    If the management cluster you prepared in the first step was deployed using k0rdent or the CAPI AWS provider,
+    you can simplify the creation of a `ClusterDeployment` manifest, and use the following template, which
+    dynamically inserts the appropriate values:
 
     ```yaml
     apiVersion: k0rdent.mirantis.com/v1beta1
@@ -134,6 +135,16 @@ Follow these steps to set up a k0smotron-hosted control plane on AWS:
     ```shell
     kubectl get awscluster <cluster-name> -o go-template="$(cat clusterdeployment.yaml.tpl)" > clusterdeployment.yaml
     ```
+
+    Or if the management cluster is deployed on EKS, use the following command:
+
+    ```shell
+    kubectl get awsmanagedcontrolplane <cluster-name> -o go-template="$(cat clusterdeployment.yaml.tpl)" > clusterdeployment.yaml
+    ```
+
+    > NOTE:
+    > For EKS management clusters, update the `spec.config.managementClusterName` parameter as described in
+    > [Setting the managementClusterName parameter](../../reference/template/template-aws.md#setting-the-managementclustername-parameter-for-hosted-control-plane-clusters).
 
 5. Apply the `ClusterTemplate`
 

--- a/docs/admin/hosted-control-plane/hcp-azure.md
+++ b/docs/admin/hosted-control-plane/hcp-azure.md
@@ -90,10 +90,11 @@ Follow these steps to set up a k0smotron-hosted control plane on Azure:
           securityGroupName: mgmt-cluster-node-nsg
     ```
 
-4. Generate the `ClusterDeployment` Manifest
+    Alternatively, you can generate the `ClusterDeployment` manifest.
 
-    To simplify the creation of a `ClusterDeployment` manifest, you can use the following template, which dynamically inserts
-    the appropriate values:
+    If the management cluster you prepared in the first step was deployed using k0rdent or the CAPI AWS provider,
+    you can simplify the creation of a `ClusterDeployment` manifest, and use the following template, which
+    dynamically inserts the appropriate values:
 
     ```yaml
     apiVersion: k0rdent.mirantis.com/v1beta1

--- a/docs/reference/template/template-aws.md
+++ b/docs/reference/template/template-aws.md
@@ -128,3 +128,23 @@ fields in the `ClusterDeployment` responsible for these settings, which depend o
 | `aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}` | `.spec.worker.nonRootVolumes` |
 
 The `nonRootVolumes` field is **a list** of [Volumes](https://cluster-api-aws.sigs.k8s.io/crd/#infrastructure.cluster.x-k8s.io/v1beta2.Volume).
+
+## Setting the `managementClusterName` parameter for Hosted Control Plane clusters
+
+The `managementClusterName` parameter is **required** for hosted control plane clusters.
+It should match the `<cluster-id>` from the `kubernetes.io/cluster/<cluster-id> = owned` tag on existing AWS network
+resources:
+
+### Management Cluster Deployed on EKS
+
+* If deployed using k0rdent (`aws-eks` template), the EKS cluster name defaults to:
+  `<namespace>_<clusterdeploymentname>-cp`, or to the value of `eksClusterName` if explicitly set.
+
+* If deployed separately (using `eksctl` or manually via the AWS console), the `<cluster-id>` is typically the
+**EKS cluster name**.
+
+### Management Cluster is EC2-Based (Self-Managed)
+
+* If deployed using k0rdent (`aws-standalone-cp` template), use the **name of the ClusterDeployment** object.
+
+* If created with Cluster API Provider AWS, use the value of `spec.clusterName` from the Cluster object.


### PR DESCRIPTION
* Added the section about the `managementClusterName` parameter. It may not always equal to the name of the AWSCluster and must be correctly configured.
* Adjusted the AWS hosted cluster deployment example with the case when the management cluster can be EKS.
* Small adjustments to azure hosted cluster deployment example.

This PR can be backported to all k0rdent versions (including enterprise).