### PR TITLE
Add a note about defaultHelmTimeout flag

### DIFF
--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -325,3 +325,22 @@ spec:
         controller:
           enableSveltosExpiredCtrl: true
 ```
+
+### Configuring Default Timeout for Helm Install and Upgrade Operations
+
+In some environments, Helm chart installations or upgrades may take longer than the default timeout of 5 minutes.
+This hardcoded limit could cause operations to fail unexpectedly if they exceeded the timeout.
+
+Starting from K0rdent v1.3.0, KCM allows you to configure the default Helm timeout using the `defaultHelmTimeout`
+controller setting:
+
+```yaml
+spec:
+  core:
+    kcm:
+      config:
+        controller:
+           defaultHelmTimeout: 20m
+```
+
+This value accepts standard duration format (e.g., 20m, 1h).


### PR DESCRIPTION
Applies starting from:

K0rdent OSS: v1.3.0
K0rdent Enterprise: v1.1.0

Related issue: https://github.com/k0rdent/kcm/pull/1830