### PR TITLE
docs: telemetry feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ site/
 __pycache__/
 *.pyc
 *.pyo
+
+# Ignore macOS-related files
+.DS_Store

--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -340,7 +340,24 @@ spec:
     kcm:
       config:
         controller:
-           defaultHelmTimeout: 20m
+          defaultHelmTimeout: 20m
 ```
 
 This value accepts standard duration format (e.g., 20m, 1h).
+
+### Configuring Telemetry
+
+To configure [Telemetry](./telemetry/index.md) options via the
+[Management](../reference/crds/index.md#management) object
+set values under the `telemetry` block, e.g. to disable collection:
+
+```yaml
+spec:
+  core:
+    kcm:
+      telemetry:
+        mode: disabled
+```
+
+Follow the [telemetry configuration page](./telemetry/configuration.md)
+for all of the possible values.

--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -348,8 +348,8 @@ This value accepts standard duration format (e.g., 20m, 1h).
 ### Configuring Telemetry
 
 To configure [Telemetry](./telemetry/index.md) options via the
-[Management](../reference/crds/index.md#management) object
-set values under the `telemetry` block, e.g. to disable collection:
+[Management](../reference/crds/index.md#management) object, 
+set values under the `telemetry` block. For example, you can disable collection by setting 'mode' to 'disabled':
 
 ```yaml
 spec:

--- a/docs/appendix/telemetry/configuration.md
+++ b/docs/appendix/telemetry/configuration.md
@@ -1,8 +1,7 @@
 # Configuring telemetry
 
-Telemetry can be configured either via the helm values during the installation
-via `--set` flag
-or via the [Management](../../reference/crds/index.md#management) object as
+{{{ docsVersionInfo.k0rdentName}}} enables you to configure telemetry either by using the `--set` flag to set helm values during installation
+or by editing the [Management](../../reference/crds/index.md#management) object for an existing management cluster, as
 shown in the [Extended Management Configuration](../appendix-extend-mgmt.md#configuring-telemetry).
 
 ## Main settings block
@@ -17,7 +16,7 @@ telemetry:
   jitter: 10              # % jitter (1..99)
 ```
 
-* `mode` controls collection and storage mechanism. `online` sends to Segment;
+* `mode` controls the collection and storage mechanism. `online` sends to Segment;
   `local` writes files; `disabled` turns it off. *(Default: `online`)*
 * `concurrency` is how many child clusters are scraped in parallel.
 * `interval` is the scrape frequency.

--- a/docs/appendix/telemetry/configuration.md
+++ b/docs/appendix/telemetry/configuration.md
@@ -1,0 +1,197 @@
+# Configuring telemetry
+
+Telemetry can be configured either via the helm values during the installation
+via `--set` flag
+or via the [Management](../../reference/crds/index.md#management) object as
+shown in the [Extended Management Configuration](../appendix-extend-mgmt.md#configuring-telemetry).
+
+## Main settings block
+
+Telemetry is configured under the `telemetry` block:
+
+```yaml
+telemetry:
+  mode: online            # disabled | local | online (default: online)
+  concurrency: 5          # scrape N clusters in parallel (1..100)
+  interval: 24h           # scrape cadence
+  jitter: 10              # % jitter (1..99)
+```
+
+* `mode` controls collection and storage mechanism. `online` sends to Segment;
+  `local` writes files; `disabled` turns it off. *(Default: `online`)*
+* `concurrency` is how many child clusters are scraped in parallel.
+* `interval` is the scrape frequency.
+* `jitter` spreads scrapes across time to avoid thundering herds.
+
+## Local mode storage settings
+
+When `telemetry.mode: local`, configure where and how files are stored:
+
+```yaml
+telemetry:
+  mode: local
+  local:
+    baseDir: /var/lib/telemetry
+    volume:
+      source: hostPath     # pvc | existing | hostPath (default)
+      # For source: pvc (dynamic provisioning)
+      pvc:
+        storageClassName: ""        # default StorageClass if empty
+        accessModes: [ReadWriteOnce]
+        volumeMode: Filesystem
+        size: 200Mi
+        annotations: {}
+      # For source: existing (use pre-created PVC)
+      existingClaim: ""
+      # For source: hostPath (static PV + matching PVC)
+      hostPath:
+        name: ""                    # defaults to <fullname>-telemetry-data
+        reclaimPolicy: Retain
+        storageClassName: "manual"
+        accessModes: [ReadWriteOnce]
+        volumeMode: Filesystem
+        size: 200Mi
+        annotations: {}
+        labels: {}
+        nodeAffinity: {}            # pin PV to a node if needed
+```
+
+* `baseDir` is the directory inside the pod where telemetry files appear;
+  when `source: hostPath`, the host path **on the node** is the same `baseDir`.
+* `volume.source` chooses between:
+  
+    - `pvc` — the chart **creates a PVC** (dynamic PV provisioning
+      **must be configured** prior).
+    - `existing` — the chart **uses an existing PVC** you name in `existingClaim`.
+    - `hostPath` *(default)* — the chart **creates a static hostPath PV +
+      matching PVC** mounted at `baseDir`.
+      Default PV settings include `persistentVolumeReclaimPolicy: Retain`
+      and `storageClassName: manual`; optional `nodeAffinity` ties
+      the PV to a specific node.
+
+> HINT: **Recommendation**
+>
+> Prefer dynamically-provisioned PVCs (`source: pvc`) or existing PVCs
+> (`source: existing`) over `hostPath`.
+> HostPath ties data to one node and is generally less stable/portable
+> for controller pods that may reschedule.
+
+## How the chart wires this up
+
+* **Only** in `local` mode, an init container (`telemetry-data-permissions`)
+  runs as root (only the `CHOWN` capability)
+  to `chown -R 65532:65532 <baseDir>` so the main controller
+  (running as non-root) can write files.
+  The main pod runs with `runAsNonRoot: true`.
+* When `source: hostPath`, the chart **creates**:
+
+    - a **PersistentVolume** with `hostPath.path: <baseDir>`,
+      `type: DirectoryOrCreate`, reclaim policy **Retain** (*default*),
+      optional `nodeAffinity`.
+    - a **matching PVC** bound by name.
+
+> NOTE: **Note on a legacy flag**
+>
+> `controller.enableTelemetry` is **deprecated in favor of the `telemetry`
+> block**. It may still appear as a container arg for backward compatibility,
+> but you should configure telemetry via the `telemetry` values going forward.
+
+## Configuration examples
+
+> NOTE:
+>
+> Replace only the snippets you need; all other values keep their defaults.
+
+### Disable telemetry entirely
+
+```yaml
+telemetry:
+  mode: disabled
+```
+
+No data is collected or stored.
+
+### Online telemetry (defaults)
+
+```yaml
+telemetry:
+  mode: online      # default
+  concurrency: 5    # default
+  interval: 24h     # default
+  jitter: 10        # default
+```
+
+Sends data to Segment.io CDP.
+
+### Local telemetry with dynamic provisioning
+
+> WARNING: Ensure dynamic PV provisioning is configured prior.
+
+```yaml
+telemetry:
+  mode: local
+  local:
+    baseDir: /var/lib/telemetry
+    volume:
+      source: pvc
+      pvc:
+        storageClassName: gp2
+        accessModes: [ReadWriteOnce]
+        size: 5Gi
+```
+
+Chart creates a PVC; files appear under `/var/lib/telemetry`
+in the pod, rotated daily.
+
+### Local telemetry with an existing PVC
+
+```yaml
+telemetry:
+  mode: local
+  local:
+    baseDir: /var/lib/telemetry
+    volume:
+      source: existing
+      existingClaim: kcm-telemetry-pvc
+```
+
+Chart uses your PVC; no PV/PVC objects are created by the chart.
+
+### Local telemetry with hostPath (single-node / pinned-node)
+
+```yaml
+telemetry:
+  mode: local
+  local:
+    baseDir: /var/lib/telemetry
+    volume:
+      source: hostPath
+      hostPath:
+        name: kcm-telemetry-hostpath
+        reclaimPolicy: Retain
+        storageClassName: manual
+        size: 10Gi
+        nodeAffinity:
+          required:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["worker-01"]
+```
+
+Chart creates a hostPath PV at `/var/lib/telemetry` and a matching PVC;
+prefer PVC-backed options in HA clusters.
+
+## Troubleshooting
+
+* **No local files appear**:
+  ensure `telemetry.mode: local` and that a volume source is configured.
+  Check the init container `telemetry-data-permissions` completed successfully.
+* **Pod unschedulable with hostPath**:
+  if the pod moves to a different node, the hostPath PV won’t be there;
+  either pin the PV with `nodeAffinity` or switch to a PVC-backed option.
+* **Conflicting settings**:
+  if you previously set `controller.enableTelemetry`, migrate to the
+  `telemetry` block; the old flag is deprecated and may be removed in a
+  future release.

--- a/docs/appendix/telemetry/configuration.md
+++ b/docs/appendix/telemetry/configuration.md
@@ -24,7 +24,7 @@ telemetry:
 
 ## Local mode storage settings
 
-When `telemetry.mode: local`, configure where and how files are stored:
+When `telemetry.mode` is set to `local`, you can configure where and how files are stored:
 
 ```yaml
 telemetry:

--- a/docs/appendix/telemetry/data_collected.md
+++ b/docs/appendix/telemetry/data_collected.md
@@ -1,0 +1,33 @@
+# What’s collected (at a glance)
+
+The KCM controller periodically scrapes each managed cluster and records:
+
+* **Fleet/size**: number of nodes, total CPU (cores) and memory, total GPU units
+  (AMD + NVIDIA).
+* **Per-node profile**: OS, architecture, kernel, Kubernetes version, and
+  flavor (e.g., k0s).
+* **GPU details**: capacity per vendor and GPU requests aggregated from pods;
+  whether NVIDIA/AMD GPU operators are installed; count of pods requesting GPUs.
+* **Virtualization**: number of [KubeVirt](https://kubevirt.io/) VMIs.
+* **Template and sync info**: [ClusterTemplate](../../reference/crds/index.md#clustertemplate)'s
+  name, chart version, sync mode, providers used by the template.
+* **User Services**: number of services defined in [ClusterDeployment](../../reference/crds/index.md#clusterdeployment)
+  and [MultiClusterService](../../reference/crds/index.md#multiclusterservice) objects.
+* **Identification labels**: cluster namespaced name,
+  [ClusterDeployment](../../reference/crds/index.md#clusterdeployment) UID,
+  and k0s cluster ID.
+
+The exact metrics and their representation vary from the mode.
+
+## Mode-specific nuances
+
+* **Online mode**: each event carries a Segment *AnonymousId* equal
+  to the Management UID.
+  Segment client context includes: **KCM build commit/name/version**,
+  **system namespace**, **runtime OS/arch**, and **timezone**.
+* **Local mode**: data is written to a **daily-rotated JSON file**
+  under a base directory, with a top-level
+  `clusters` array containing per-cluster `counters` and `labels`.
+  Metrics are represented as counters; hence, some of the `online`
+  mode's metrics are flattened or omitted due to high cardinality
+  such as **per-node profile**.

--- a/docs/appendix/telemetry/index.md
+++ b/docs/appendix/telemetry/index.md
@@ -1,0 +1,16 @@
+# Telemetry introduction
+
+This document explains how **{{{ docsVersionInfo.k0rdentName }}}** collects
+telemetry from *child* (managed) clusters, what data is gathered, where it
+is stored for each mode, and how to configure the feature through either
+Helm values or the [Management](../../reference/crds/index.md#management) object.
+
+> **Why telemetry?**
+> Telemetry helps the {{{ docsVersionInfo.k0rdentName }}} team understand
+> real-world environments (cluster sizes, versions, GPU usage, etc.)
+> to improve reliability and guide roadmap priorities. Data is
+> scoped to operational characteristics and includes no application payloads.
+>
+> **Default behavior**
+> Telemetry is **enabled by default** with mode `online`, which sends
+> metrics to [Segment.io CDP](https://segment.com/) workspace owned by our team.

--- a/docs/appendix/telemetry/modes.md
+++ b/docs/appendix/telemetry/modes.md
@@ -1,0 +1,32 @@
+# Modes
+
+| Mode | What happens | Where it goes |
+| ---- | ------------ | ------------- |
+| `disabled` | Collection is off | — |
+| `online` *(default)* | Events are batched and sent to **Segment.io** with the default context fields listed [below](#privacy-and-identity-in-online-mode) | [Segment.io CDP](https://segment.com/) |
+| `local` | Events are written to **files** and rotated **daily** | Files on a **PersistentVolume** mounted at the **base directory** |
+
+Local files resemble:
+
+```json
+{
+  "clusters": [
+    {
+      "counters": { "...": "..." },
+      "labels": {
+        "cluster": "ns/name",
+        "clusterDeploymentID": "uid",
+        "clusterID": "kube-system:uuid"
+      }
+    }
+  ]
+}
+```
+
+## Privacy and identity in `online` mode
+
+When operating in `online` mode, each event includes a Segment context built
+from the running KCM controller and environment
+(build commit/name/version, system namespace, runtime OS/arch, timezone),
+and uses the Management UID as an *AnonymousId* to bind events to
+a management cluster — but not to an individual user.

--- a/docs/concepts/k0rdent-architecture.md
+++ b/docs/concepts/k0rdent-architecture.md
@@ -13,7 +13,7 @@ The key principles of the architecture include:
 * Support for integration with custom components downstream
 
 > NOTE:
-> This document is a ongoing work in progress, and we would welcome suggestions and questions. 
+> This document is a ongoing work in progress, and we would welcome suggestions and questions.
 
 ## Overview
 
@@ -43,7 +43,7 @@ We’ll take a closer look at these pieces under [Roles and Responsibilities](#r
 
 ## Cluster Deployments
 
-A cluster deployment is also known as a child cluster, or a workload cluster. It’s a Kubernetes cluster provisioned and managed by the management cluster, and it’s where developers run their applications and workloads. These are “regular” Kubernetes clusters, and don’t host any management components. Clusters are fully isolated from the management cluster via namespaces, and also from each other, making it possible to create multi-tenant environments. 
+A cluster deployment is also known as a child cluster, or a workload cluster. It’s a Kubernetes cluster provisioned and managed by the management cluster, and it’s where developers run their applications and workloads. These are “regular” Kubernetes clusters, and don’t host any management components. Clusters are fully isolated from the management cluster via namespaces, and also from each other, making it possible to create multi-tenant environments.
 
 You can tailor a child cluster to specific use cases, with customized addons such as ingress controllers, monitoring tools, and logging solutions. You can also define specific Kubernetes configurations (for example, network policies, storage classes, and security policies) so they work for you and your applications or environments.
 
@@ -61,14 +61,14 @@ One of the important tenets of the platform engineering philosophy is the use of
 Major template types used in {{{ docsVersionInfo.k0rdentName }}} include:
 
 * **Cluster Templates:** `ClusterTemplate` objects define clusters in coordination with the clouds and infrastructures on which they run. They're designed to be immutable; they get invoked by {{{ docsVersionInfo.k0rdentName }}} objects such as `ClusterDeployment` objects to create and manage individual clusters and groups of clusters.
-* **Service Templates:** `ServiceTemplate` objects define services, addons, and workloads that run on clusters. They're also designed to be immutable, and get invoked by `ClusterDeployment` objects and other {{{ docsVersionInfo.k0rdentName }}} objects so that IDPs/platforms can be declared and managed as units. 
+* **Service Templates:** `ServiceTemplate` objects define services, addons, and workloads that run on clusters. They're also designed to be immutable, and get invoked by `ClusterDeployment` objects and other {{{ docsVersionInfo.k0rdentName }}} objects so that IDPs/platforms can be declared and managed as units.
 
 ## Roles and responsibilities
 
 {{{ docsVersionInfo.k0rdentName }}} was designed to be used by several groups of people, with hierarchical and complementary roles and responsibilities. You may have your own names for them, but we’ll refer to them as:
 
 * **Platform Architect:** This person or team has global responsibility to the business and technical stakeholders for designing IDPs/platforms for later adaptation to particular clouds and infrastructures, workloads, performance and cost objectives, security and regulatory regimes, and operational requirements. {{{ docsVersionInfo.k0rdentName }}} enables Platform Architects to create sets of reusable `ClusterTemplate` and `ServiceTemplate` objects, closely defining IDPs/platforms in the abstract.
-* **Platform Lead:** This person or team (sometimes referred to as 'CloudOps') is primarily responsible for actions corresponding to {{{ docsVersionInfo.k0rdentName }}} Cluster Manager (KCM). They adapt `ClusterTemplate` objects to the correct cloud, and they make sure that everything is working properly. They’re also responsible for limiting the Project Team’s access to the `Cluster` and `Service` templates necessary to do their jobs. For example, they might limit the templates that can be deployed to an approved set, or provide CAPI operators for only the clouds on which the company wants applications to run, helping to eliminate shadow IT. 
+* **Platform Lead:** This person or team (sometimes referred to as 'CloudOps') is primarily responsible for actions corresponding to {{{ docsVersionInfo.k0rdentName }}} Cluster Manager (KCM). They adapt `ClusterTemplate` objects to the correct cloud, and they make sure that everything is working properly. They’re also responsible for limiting the Project Team’s access to the `Cluster` and `Service` templates necessary to do their jobs. For example, they might limit the templates that can be deployed to an approved set, or provide CAPI operators for only the clouds on which the company wants applications to run, helping to eliminate shadow IT.
 * **Platform Engineer:** This person or team is responsible for the day-to-day management of the environment. They use `ClusterTemplate` and `ServiceTemplate` objects provided by the Platform Lead (as authorized to do so) and may create additional `ServiceTemplate` objects to customize their own Kubernetes cluster so that it's appropriate for their application.
 
 ## Credentials
@@ -82,7 +82,7 @@ To solve this problem, {{{ docsVersionInfo.k0rdentName }}} lets you create a `Cr
 3. Developers reference the `Credential` object, which gives the cluster the ability to access these credentials (little “c”) without having to expose them to developers directly.
 
 > NOTE:
-> To be sure credentials are not visible to developers, make sure to [limit access](../admin/access/rbac/roles-summary.md#limit-credential-access) to the `kcm-system` namespace.
+> To be sure credentials are not visible to developers, make sure to [limit access](../admin/access/rbac/limiting-access.md#limiting-credential-access) to the `kcm-system` namespace.
 
 ## TL;DR - Conclusion
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,11 @@ nav:
     - Understanding the dry run: appendix/appendix-dryrun.md
     - Cloud provider credentials management in CAPI: appendix/appendix-providers.md
     - Running k0rdent on ARM64: appendix/arm64.md
+    - Telemetry:
+      - Telemetry Description: appendix/telemetry/index.md
+      - Data Collected: appendix/telemetry/data_collected.md
+      - Modes: appendix/telemetry/modes.md
+      - Configuration: appendix/telemetry/configuration.md
   - Release Notes:
     - Overview: release-notes/index.md
     - v1.0.0: release-notes/release-notes-v1.0.0.md


### PR DESCRIPTION
Include documentation for the telemetry (child) collection feature.

Introduces a new section onto the `Appendix` added via the `mkdocs.yml` configuration file with the following new files:

- `docs/appendix/telemetry/index.md` with a brief intro;
- `docs/appendix/telemetry/data_collected.md` with information on what is collected at a glance;
- `docs/appendix/telemetry/modes.md` with per-mode information;
- `docs/appendix/telemetry/configuration.md` with docs about configuration and configuration examples.

Adds a new entry to the `.gitignore` for more convenient development on macOS.

Fixes incorrect link in `docs/k0rdent-architecture.md` lost in the https://github.com/k0rdent/docs/commit/60144cbbda0e076a88ba8a0b3e320332d5c39f25 commit.

Closes k0rdent/kcm#1853