### PR TITLE
docs: fix broken links to ksm-related docs

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -129,7 +129,7 @@ This Administration Guide provides information on:
 
 - [Installing and preparing {{{ docsVersionInfo.k0rdentName }}} for use](installation/index.md)
 - [Working with clusters](clusters/index.md)
-- [Working with services](services/index.md)
+- [Working with services](ksm/index.md)
 - [Hosted control planes](hosted-control-plane/index.md)
 - [{{{ docsVersionInfo.k0rdentName }}} Observability & FinOps](kof/index.md)
 - [Upgrading {{{ docsVersionInfo.k0rdentName }}}](upgrade/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,6 @@ plugins:
         admin-adopting-clusters.md: admin/clusters/admin-adopting-clusters.md
         admin-hosted-control-planes.md: admin/hosted-control-plane/index.md
         admin-troubleshooting-aws-vpcs.md: troubleshooting/admin-troubleshooting-aws-vpcs.md
-        admin-service-templates.md: admin/services/admin-service-templates.md
         ksm-service-templates.md: admin/ksm/ksm-service-templates.md
         ksm-multiclusterservice.md: admin/ksm/ksm-multiclusterservice.md
         ksm-self-management.md: admin/ksm/ksm-self-management.md


### PR DESCRIPTION
(cherry picked from commit 6ff588eea9ec90f5d096400cc38c15583558848a)