### PR TITLE
docs: amends restore config, adds cleanup field

### DIFF
--- a/docs/admin/backup/caveats.md
+++ b/docs/admin/backup/caveats.md
@@ -62,7 +62,4 @@ spec:
 > deletes it from both
 > the management cluster and from the cloud storage.
 
-Optionally, delete the created `DeleteBackupRequest` object
-from the cluster after `Backup` has been deleted.
-
 For reference, follow the [official documentation](https://velero.io/docs/v1.15/backup-reference/#deleting-backups).

--- a/docs/admin/backup/customization.md
+++ b/docs/admin/backup/customization.md
@@ -22,16 +22,16 @@ The [Velero helm chart](https://vmware-tanzu.github.io/helm-charts/) is supplied
      --create-namespace \
      --namespace kcm-system \
      --set-file velero.credentials.secretContents.cloud=<full-path-to-file> \
-     --set velero.credentials.useSecret=true \
-     --set velero.backupsEnabled=true \
-     --set velero.configuration.backupStorageLocation[0].name=<backup-storage-location-name> \
-     --set velero.configuration.backupStorageLocation[0].provider=<provider-name> \
-     --set velero.configuration.backupStorageLocation[0].bucket=<bucket-name> \
-     --set velero.configuration.backupStorageLocation[0].config.region=<region> \
-     --set velero.initContainers[0].name=velero-plugin-for-<provider-name> \
-     --set velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
-     --set velero.initContainers[0].volumeMounts[0].mountPath=/target \
-     --set velero.initContainers[0].volumeMounts[0].name=plugins
+     --set regional.velero.credentials.useSecret=true \
+     --set regional.velero.backupsEnabled=true \
+     --set regional.velero.configuration.backupStorageLocation[0].name=<backup-storage-location-name> \
+     --set regional.velero.configuration.backupStorageLocation[0].provider=<provider-name> \
+     --set regional.velero.configuration.backupStorageLocation[0].bucket=<bucket-name> \
+     --set regional.velero.configuration.backupStorageLocation[0].config.region=<region> \
+     --set regional.velero.initContainers[0].name=velero-plugin-for-<provider-name> \
+     --set regional.velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
+     --set regional.velero.initContainers[0].volumeMounts[0].mountPath=/target \
+     --set regional.velero.initContainers[0].volumeMounts[0].name=plugins
     ```
 
 1. Create or modify the existing `Management` object in the `.spec.config.kcm`.

--- a/docs/admin/backup/index.md
+++ b/docs/admin/backup/index.md
@@ -24,6 +24,7 @@ The main goal of the feature is to provide:
 * **Disaster Recovery:** The ability to restore {{{ docsVersionInfo.k0rdentName }}} on another management cluster, plus ensuring that clusters are not
   recreated or lost.
 * **Rollback:** The possibility to manually restore after a specific event, such as a failed {{{ docsVersionInfo.k0rdentName }}} upgrade
+
 ## Velero as Provider for Management Backups
 
 [`Velero`](https://velero.io/) is an open-source tool that simplifies backing up and restoring clusters as well as individual resources. It seamlessly integrates into the {{{ docsVersionInfo.k0rdentName }}} management environment to provide robust disaster recovery capabilities.

--- a/docs/admin/backup/prepare-backups.md
+++ b/docs/admin/backup/prepare-backups.md
@@ -2,7 +2,7 @@
 
 ## Preparation
 
-> NOTE: 
+> NOTE:
 > The following instructions are tailored for AWS. Please adapt them to your chosen platform and storage.
 
 Before you create a manual one-off or scheduled backup, review the steps below and update your configuration accordingly:
@@ -14,6 +14,7 @@ Before you create a manual one-off or scheduled backup, review the steps below a
     ```sh
     kubectl get management kcm -n kcm-system -o yaml > management.yaml
     ```
+
     then edit the `management.yaml` file so that the velero plugin details are filled in under `spec.core.kcm`:
 
     ```yaml
@@ -62,13 +63,14 @@ Before you create a manual one-off or scheduled backup, review the steps below a
 
       > NOTE:
       > If you're using EKS, the "user" is actually a role. If you get an error such as...
-      > 
-      > ```
+      >
+      > ```text
       > AccessDenied: User: arn:aws:sts::026090528175:assumed-role/eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A/i-0f7dad2d91447f173 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::nick-chase-backup-bucket" because no identity-based policy allows the s3:ListBucket action
       > ```
-      > 
+      >
       > ...you can extract the role from the message (in this example, it's the assumed-role) and create the policy. For example:
-      > ```
+      >
+      > ```text
       > aws iam put-role-policy
       > --role-name eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A
       > --policy-name velero
@@ -76,11 +78,13 @@ Before you create a manual one-off or scheduled backup, review the steps below a
       > ```
 
       Generate the necessary base64-encoded credentials using:
+
       ```sh
       base64 -w0 credentials.txt; echo
       ```
 
       Use this base64 value in the `data.cloud` field in the `creds-and-backup-storage-location.yaml` you'll create next. Also make sure to substitute the appropriate `REGION-NAME` and `BUCKET-NAME`:
+
       ```yaml
       ---
       apiVersion: v1
@@ -115,22 +119,29 @@ Before you create a manual one-off or scheduled backup, review the steps below a
       ```
 
 1. Create the necessary Kubernetes resources in your k0rdent cluster by applying the YAML to the management cluster:
+
     ```sh
     kubectl apply -f creds-and-backup-storage-location.yaml
     kubectl apply -f management.yaml
     ```
+
 1. Confirm that the previous steps were applied correctly:
+
     ```sh
     kubectl get management kcm -n kcm-system -o yaml
     ```
-    The management configuration yaml should have the new velero plugin details, as shown in step 2. 
+
+    The management configuration yaml should have the new velero plugin details, as shown in step 2.
 
     Now make sure the `backupstoragelocation` shows as `Available`:
+
     ```sh
     kubectl get backupstoragelocation -n kcm-system
     ```
+
     ```console
     NAME     PHASE       LAST VALIDATED   AGE   DEFAULT
     aws-s3   Available   27s              2d    true
     ```
+
 You can get more information on how to build these objects at the [official Velero documentation](https://velero.io/docs/v1.15/locations).

--- a/docs/admin/backup/restore.md
+++ b/docs/admin/backup/restore.md
@@ -21,10 +21,10 @@ In the event of disaster, you can restore from a backup by doing the following:
      --set controller.createAccessManagement=false \
      --set controller.createRelease=false \
      --set controller.createTemplates=false \
-     --set velero.initContainers[0].name=velero-plugin-for-<provider-name> \
-     --set velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
-     --set velero.initContainers[0].volumeMounts[0].mountPath=/target \
-     --set velero.initContainers[0].volumeMounts[0].name=plugins
+     --set regional.velero.initContainers[0].name=velero-plugin-for-<provider-name> \
+     --set regional.velero.initContainers[0].image=velero/velero-plugin-for-<provider-name>:<provider-plugin-tag> \
+     --set regional.velero.initContainers[0].volumeMounts[0].mountPath=/target \
+     --set regional.velero.initContainers[0].volumeMounts[0].name=plugins
     ```
 
 1. Create the `BackupStorageLocation`/`Secret` objects that were created during the [preparation stage](./prepare-backups.md)

--- a/docs/admin/clusters/deploy-cluster.md
+++ b/docs/admin/clusters/deploy-cluster.md
@@ -1,6 +1,6 @@
 # Deploying a Cluster
 
-{{{ docsVersionInfo.k0rdentName }}} is designed to simplify the process of deploying and managing Kubernetes clusters across various cloud platforms. It does this through the use of `ClusterDeployment` objects, which include all of the information {{{ docsVersionInfo.k0rdentName }}} needs to know in order to create the cluster you're looking for. This `ClusterDeployment` system relies on predefined templates and credentials. 
+{{{ docsVersionInfo.k0rdentName }}} is designed to simplify the process of deploying and managing Kubernetes clusters across various cloud platforms. It does this through the use of `ClusterDeployment` objects, which include all of the information {{{ docsVersionInfo.k0rdentName }}} needs to know in order to create the cluster you're looking for. This `ClusterDeployment` system relies on predefined templates and credentials.
 
 A cluster deployment typically involves:
 
@@ -15,7 +15,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     Credentials are essential for {{{ docsVersionInfo.k0rdentName }}} to communicate with the infrastructure provider (for example, AWS, Azure, vSphere). These credentials enable {{{ docsVersionInfo.k0rdentName }}} to provision resources such as virtual machines, networking components, and storage.
 
     `Credential` objects are generally created ahead of time and made available to users, so before you look into creating a
-    new one be sure what you're looking for doesn't already exist. You can see all of the existing `Credential` objects by 
+    new one be sure what you're looking for doesn't already exist. You can see all of the existing `Credential` objects by
     querying the management cluster:
 
     ```bash
@@ -26,7 +26,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
 
     Start by creating a `Credential` object that includes all required authentication details for your chosen infrastructure provider. Follow the instructions in the [chapter about credential management](../access/credentials/index.md), as well as the specific instructions for your [target infrastructure](../installation/prepare-mgmt-cluster/index.md).
 
-    > TIP: 
+    > TIP:
     > Double-check to make sure that your credentials have sufficient permissions to create resources on the target infrastructure.
 
 2. Select a Template
@@ -42,6 +42,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
+
     ```console
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
@@ -87,6 +88,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
       template: <template-name>
       credential: <infrastructure-provider-credential-name>
       dryRun: <"true" or "false" (default: "false")>
+      cleanupOnDeletion: <"true" or "false" (default: "false")>
       config:
         <cluster-configuration>
     ```
@@ -113,7 +115,14 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
           instanceType: t3.small
           rootVolumeSize: 32
     ```
+
     Note that the `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+
+    > TIP:
+    > If automatic cleanup of potentially orphaned *LoadBalancer Services* and *Storage devices* during deletion of
+    > the `ClusterDeployment` object is required, set `.spec.cleanupOnDeletion` to `true`.
+    > This is a best-effort cleanup: if there is no possibility to acquire a managed cluster's kubeconfig,
+    > the cleanup will **not** happen.
 
 4. Apply the Configuration
 
@@ -157,6 +166,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     ```bash
     kubectl get secret -n <namespace> <cluster-name>-kubeconfig -o=jsonpath={.data.value} | base64 -d > kubeconfig
     ```
+
     You can then use this file to access the cluster, as in:
 
     ```bash

--- a/docs/user/user-create-cluster.md
+++ b/docs/user/user-create-cluster.md
@@ -1,6 +1,6 @@
 # Deploying a Cluster
 
-{{{ docsVersionInfo.k0rdentName }}} simplifies the process of deploying and managing Kubernetes clusters across various cloud platforms through the use of `ClusterDeployment` objects, which include all of the information {{{ docsVersionInfo.k0rdentName }}} needs to know in order to create the cluster you want. This `ClusterDeployment` system relies on predefined templates and credentials. 
+{{{ docsVersionInfo.k0rdentName }}} simplifies the process of deploying and managing Kubernetes clusters across various cloud platforms through the use of `ClusterDeployment` objects, which include all of the information {{{ docsVersionInfo.k0rdentName }}} needs to know in order to create the cluster you want. This `ClusterDeployment` system relies on predefined templates and credentials.
 
 A cluster deployment typically involves:
 
@@ -19,6 +19,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     ```bash
     kubectl get credentials -n accounting
     ```
+
     When you find a `Credential` that looks appropriate, you can get more information by `describe`-ing it, as in:
 
     ```bash
@@ -46,7 +47,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     If the `Credential` you need doesn't yet exist, you can ask your cloud administrator to create it, or you can
     follow the instructions in the [Credential System](../admin/access/credentials/index.md), as well as the specific instructions for your [target infrastructure](../admin/installation/prepare-mgmt-cluster/index.md), to create it yourself.
 
-    > TIP: 
+    > TIP:
     > Double-check to make sure that your credentials have sufficient permissions to create resources on the target infrastructure.
 
 2. Select a Template
@@ -62,6 +63,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
+
     ```console
     NAMESPACE    NAME                            VALID
     kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
@@ -89,7 +91,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
 
 3. Create a ClusterDeployment YAML Configuration
 
-    Once you have the `Credential` and the `ClusterTemplate` you can create the `ClusterDeployment` object configuration. 
+    Once you have the `Credential` and the `ClusterTemplate` you can create the `ClusterDeployment` object configuration.
     It includes:
 
     * The template to use.
@@ -108,6 +110,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
       template: <template-name>
       credential: <infrastructure-provider-credential-name>
       dryRun: <"true" or "false" (default: "false")>
+      cleanupOnDeletion: <"true" or "false" (default: "false")>
       config:
         <cluster-configuration>
     ```
@@ -131,7 +134,14 @@ Follow these steps to deploy a standalone Kubernetes cluster:
         worker:
           instanceType: t3.small
     ```
+
     Note that the `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+
+    > TIP:
+    > If automatic cleanup of potentially orphaned *LoadBalancer Services* and *Storage devices* during deletion of
+    > the `ClusterDeployment` object is required, set `.spec.cleanupOnDeletion` to `true`.
+    > This is a best-effort cleanup: if there is no possibility to acquire a managed cluster's kubeconfig,
+    > the cleanup will **not** happen.
 
 4. Apply the Configuration
 
@@ -141,7 +151,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     kubectl apply -f clusterdeployment.yaml
     ```
 
-    This step submits your deployment request to {{{ docsVersionInfo.k0rdentName }}}. 
+    This step submits your deployment request to {{{ docsVersionInfo.k0rdentName }}}.
 
 5. Verify Deployment Status
 
@@ -168,6 +178,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     ```bash
     kubectl get secret -n <namespace> <cluster-name>-kubeconfig -o=jsonpath={.data.value} | base64 -d > kubeconfig
     ```
+
     You can then use this file to access the cluster, as in:
 
     ```bash
@@ -180,7 +191,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
 ## Cleanup
 
 When you're finished you'll want to remove the cluster. Because the cluster is represented by the `ClusterDeployment` object,
-deleting the cluster is a simple matter of deleting that object.  For example:
+deleting the cluster is a simple matter of deleting that object. For example:
 
 ```bash
 kubectl delete clusterdeployment <cluster-name> -n kcm-system


### PR DESCRIPTION
Amends velero configurations in regards to the new `regional` chart, that had been added as a part of the region clusters feature.

Adds the new field of the `cld` resource, that enabled cleanup of potentially orphaned LB and Storage cloud resources.

Closes k0rdent/2a-internal#264