### PR TITLE
fix: proper allowedNamespaces in all aws identity examples

### DIFF
--- a/docs/admin/installation/prepare-mgmt-cluster/aws.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/aws.md
@@ -259,9 +259,7 @@
         k0rdent.mirantis.com/component: "kcm"
     spec:
       secretRef: aws-cluster-identity-secret
-      allowedNamespaces:
-        selector:
-          matchLabels: {}
+      allowedNamespaces: {}
     ```
 
     Notice that the `secretRef` references the `Secret` you created in the previous step.

--- a/docs/admin/regional-clusters/creating-credential-in-region.md
+++ b/docs/admin/regional-clusters/creating-credential-in-region.md
@@ -60,9 +60,7 @@ with the cloud. This should be done using the regional cluster kubeconfig so the
        k0rdent.mirantis.com/component: "kcm"
    spec:
      secretRef: aws-cluster-identity-secret
-     allowedNamespaces:
-       selector:
-         matchLabels: {}
+     allowedNamespaces: {}
    ```
 
    Notice that the `secretRef` references the `Secret` you created in the previous step.

--- a/docs/quickstarts/quickstart-2-aws.md
+++ b/docs/quickstarts/quickstart-2-aws.md
@@ -265,9 +265,7 @@ metadata:
     k0rdent.mirantis.com/component: "kcm"
 spec:
   secretRef: aws-cluster-identity-secret
-  allowedNamespaces:
-    selector:
-      matchLabels: {}
+  allowedNamespaces: {}
 ```
 
 Note that the `spec.secretRef` is the same as the `metadata.name` of the secret we just created.


### PR DESCRIPTION
Due to the upgrade of the provider the old examples of the AWS cluster identities are no longer valid.

PR is to 1.4.0, but it must be ported to main as well