### PR TITLE
Removed 'copy' icon from console output in 1.4.0

### DIFF
--- a/docs/admin/access/rbac/limiting-access.md
+++ b/docs/admin/access/rbac/limiting-access.md
@@ -31,7 +31,7 @@ and nothing else:
 ```bash
 kubectl describe clusterrole kcm-credentials-viewer-role
 ```
-```console
+```console { .no-copy }
 Name:         kcm-credentials-viewer-role
 Labels:       app.kubernetes.io/managed-by=Helm
               helm.toolkit.fluxcd.io/name=kcm
@@ -109,7 +109,7 @@ new `ServiceTemplate` objects:
 ```bash
 kubectl describe clusterrole kcm-namespace-editor-role -n kcm-system
 ```
-```console
+```console { .no-copy }
 Name:         kcm-namespace-editor-role
 Labels:       app.kubernetes.io/managed-by=Helm
               helm.toolkit.fluxcd.io/name=kcm

--- a/docs/admin/backup/prepare-backups.md
+++ b/docs/admin/backup/prepare-backups.md
@@ -53,7 +53,7 @@ Before you create a manual one-off or scheduled backup, review the steps below a
 
       First create a file called `credentials.txt` with your credentials, as in:
 
-      ```console
+      ```console { .no-copy }
       [default]
       aws_access_key_id = EXAMPLE_ACCESS_KEY_ID
       aws_secret_access_key = EXAMPLE_SECRET_ACCESS_KEY
@@ -140,7 +140,7 @@ Before you create a manual one-off or scheduled backup, review the steps below a
     kubectl get backupstoragelocation -n kcm-system
     ```
 
-    ```console
+    ```console { .no-copy }
     NAME     PHASE       LAST VALIDATED   AGE   DEFAULT
     aws-s3   Available   27s              2d    true
     ```

--- a/docs/admin/backup/scheduled-backups.md
+++ b/docs/admin/backup/scheduled-backups.md
@@ -34,7 +34,7 @@ Confirm the backup creation was successful by navigating to the appropriate stor
 kubectl get managementbackup
 ```
 The `managementbackup` should show as `Completed`:
-```console
+```console { .no-copy }
 NAME              LASTBACKUPSTATUS   NEXTBACKUP   AGE
 example-backup    Completed                       8m  
 ```

--- a/docs/admin/clusters/admin-adopting-clusters.md
+++ b/docs/admin/clusters/admin-adopting-clusters.md
@@ -69,7 +69,7 @@ Follow these steps to adopt an existing cluster:
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -150,7 +150,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     kubectl get nodes -o wide
     ```
-    ```console
+    ```console { .no-copy }
     NAME             STATUS   ROLES           AGE   VERSION       INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
     ip-172-31-8-77   Ready    control-plane   9d    v1.33.2+k0s   172.31.8.77   <none>        Ubuntu 24.04.2 LTS   6.8.0-1029-aws   containerd://1.7.27
     ```
@@ -178,7 +178,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     base64 /path/to/kubeconfig
     ```
-    ```console
+    ```console { .no-copy }
     YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhv
     cml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VSQlJF
     ...
@@ -221,7 +221,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     kubectl apply -f adopt-creds.yaml
     ```
-    ```console
+    ```console { .no-copy }
     secret/self-adopt-cluster-kubeconfig created
     credential.k0rdent.mirantis.com/self-adopt-cluster-credential created
     ```
@@ -233,7 +233,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     kubectl get ClusterTemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-0-2-0           true
     adopted-cluster-1-0-0           true
@@ -262,7 +262,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     kubectl apply -f self-adopt-cluster.yaml
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com/self-adopted-mgmt created
     ```
 
@@ -271,7 +271,7 @@ For example, adopting a k0s-based management cluster might look like this:
     ```bash
     kubectl get clusterdeployment -A
     ```
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                READY   SERVICES   TEMPLATE                MESSAGES          AGE
     kcm-system   self-adopted-mgmt   True    0/0        adopted-cluster-1-0-1   Object is ready   14s
     ```

--- a/docs/admin/clusters/deploy-cluster.md
+++ b/docs/admin/clusters/deploy-cluster.md
@@ -48,7 +48,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     kubectl get clustertemplate -n kcm-system
     ```
 
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-eks-multi.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-eks-multi.md
@@ -19,7 +19,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
      export AWS_SESSION_TOKEN="EXAMPLE_SESSION_TOKEN"
      aws configure
      ```
-     ```console
+     ```console { .no-copy }
      AWS Access Key ID [EXAMPLE_ACCESS_KEY_ID]:
      AWS Secret Access Key [EXAMPLE_SECRET_ACCESS_KEY]:
      Default region name [YOUR_AWS_REGION]:
@@ -32,7 +32,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
      sudo mv /tmp/eksctl /usr/local/bin
      eksctl version
      ```
-     ```console
+     ```console { .no-copy }
      0.211.0
      ```
 
@@ -45,7 +45,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     --region <YOUR_AWS_REGION> \
     --without-nodegroup
     ```
-    ```console
+    ```console { .no-copy }
     2025-03-05 22:26:02 [ℹ]  eksctl version 0.211.0
     ...
     2025-03-05 22:36:14 [✔]  all EKS cluster resources for "CLUSTER_NAME" have been created
@@ -65,7 +65,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     --nodes-max 3 \
     --node-labels "role=control-plane" 
     ```
-    ```console
+    ```console { .no-copy }
     2025-03-05 22:57:15 [ℹ]  will use version 1.31 for new nodegroup(s) based on control plane version
     2025-03-05 22:57:18 [ℹ]  nodegroup "nickchasek0rdentcontroller-group" will use "" [AmazonLinux2/1.31]
     2025-03-05 22:57:19 [ℹ]  1 nodegroup (nickchasek0rdentcontroller-group) was included (based on the include/exclude rules)
@@ -108,7 +108,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     ```bash
     kubectl get nodes
     ```
-    ```console
+    ```console { .no-copy }
     NAME                                              STATUS   ROLES    AGE    VERSION
     nodename1.compute.internal   Ready    <none>   4h1m   v1.31.7-eks-5d632ec
     nodename2.compute.internal   Ready    <none>   4h1m   v1.31.7-eks-5d632ec
@@ -119,14 +119,14 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     ```bash
     kubectl taint nodes nodename1.compute.internal node-role.kubernetes.io/control-plane=true:NoSchedule
     ```
-    ```console
+    ```console { .no-copy }
     node/nodename1.ca-central-1.compute.internal tainted
     ```
     Now verify the taints:
     ```bash
     kubectl describe nodes | grep -A 5 "Taints:"
     ```
-    ```console
+    ```console { .no-copy }
     Taints:             node-role.kubernetes.io/control-plane=true:NoSchedule
     Unschedulable:      false
     Lease:
@@ -162,7 +162,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     --nodes-max 5 \
     --node-labels "role=worker"
     ```
-    ```console
+    ```console { .no-copy }
     2025-03-06 03:10:48 [ℹ]  will use version 1.31 for new nodegroup(s) based on control plane version
     ...
     2025-03-06 03:13:38 [✔]  created 1 managed nodegroup(s) in cluster "CLUSTER_NAME"
@@ -173,7 +173,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     ```bash
     kubectl get nodes
     ```
-    ```console
+    ```console { .no-copy }
     NAME                                              STATUS   ROLES    AGE     VERSION
     nodename1.compute.internal   Ready    <none>   4h14m   v1.31.7-eks-5d632ec
     nodename4.compute.internal   Ready    <none>   79s     v1.31.7-eks-5d632ec
@@ -204,7 +204,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     ```bash
     kubectl get pods -o wide
     ```
-    ```console
+    ```console { .no-copy }
     No resources found in default namespace.
     ```
 

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-multi.md
@@ -61,7 +61,7 @@ Follow these steps to install and prepare a multinode [k0s kubernetes](https://k
     ```bash
     sudo k0s kubectl get namespaces
     ```
-    ```console
+    ```console { .no-copy }
     NAME              STATUS   AGE
     default           Active   5m15s
     k0s-autopilot     Active   5m11s
@@ -121,7 +121,7 @@ Once the contoller is up, you can add a worker node by creating a "join token" a
     ```bash
     sudo k0s kubectl get nodes
     ```
-    ```console
+    ```console { .no-copy }
     NAME              STATUS     ROLES    AGE     VERSION
     ip-172-31-9-107   Ready      <none>   3m39s   v1.33.1+k0s
     ```
@@ -161,7 +161,7 @@ To create a join token for the new controller, follow these steps.
     ```bash
     sudo k0s status
     ```
-    ```console
+    ```console { .no-copy }
     Version: v1.33.1+k0s.1
     Process ID: 1489
     Role: controller
@@ -176,7 +176,7 @@ Use the Kubernetes 'kubectl' command-line tool that comes with k0s binary to dep
 ```bash
 sudo k0s kubectl get nodes
 ```
-```console
+```console { .no-copy }
 NAME   STATUS   ROLES    AGE    VERSION
 k0s    Ready    <none>   4m6s   v1.33.1+k0s
 ```
@@ -196,7 +196,7 @@ sudo apt-get install -y kubectl
 
 To use `kubectl` directly or to access the cluster from another machine, copy the `KUBECONFIG`, which is located on the controllers at:
 
-```console
+```console { .no-copy }
 /var/lib/k0s/pki/admin.conf
 ```
 

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-single.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-k0s-single.md
@@ -60,7 +60,7 @@ Follow these steps to install and prepare a [k0s kubernetes](https://k0sproject.
 
     Again, you should see the single k0s node, but by this time it should have had its role assigned, as in:
 
-    ```console
+    ```console { .no-copy }
     NAME              STATUS   ROLES           AGE   VERSION
     ip-172-31-29-61   Ready    control-plane   25m   v1.31.2+k0s
     ```
@@ -83,7 +83,7 @@ Follow these steps to install and prepare a [k0s kubernetes](https://k0sproject.
 
 To use a tool like Lens or to access the cluster from another machine, copy the `KUBECONFIG`, which is located at:
 
-```console
+```console { .no-copy }
 /var/lib/k0s/pki/admin.conf
 ```
 

--- a/docs/admin/installation/install-k0rdent.md
+++ b/docs/admin/installation/install-k0rdent.md
@@ -7,7 +7,7 @@ The actual management cluster is a Kubernetes cluster with the {{{ docsVersionIn
 ```bash
 helm install kcm {{{ extra.docsVersionInfo.ociRegistry }}} --version {{{ extra.docsVersionInfo.k0rdentDotVersion }}} -n kcm-system --create-namespace
 ```
-```console
+```console { .no-copy }
 Pulled: ghcr.io/k0rdent/kcm/charts/kcm:{{{ extra.docsVersionInfo.k0rdentDotVersion }}}
 Digest: {{{ extra.docsVersionInfo.k0rdentDigestValue }}}
 NAME: kcm

--- a/docs/admin/installation/prepare-mgmt-cluster/aws.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/aws.md
@@ -63,7 +63,7 @@
     AVAILABLE=$((LIMIT - USED))
     echo "Available Public IPs: $AVAILABLE"
     ```
-    ```console
+    ```console { .no-copy }
     Available Public IPs: 5
     ```
 
@@ -82,7 +82,7 @@
     aws service-quotas list-requested-service-quota-change-history \
         --service-code ec2
     ```
-    ```console
+    ```console { .no-copy }
     {
         "RequestedQuotas": [
             {
@@ -112,7 +112,7 @@
     ```bash
     aws iam create-user --user-name k0rdentUser
     ```
-    ```console
+    ```console { .no-copy }
     {
       "User": {
         "Path": "/",
@@ -139,7 +139,7 @@
     ```bash
     aws iam list-policies --scope Local
     ```
-    ```console
+    ```console { .no-copy }
     {
       "Policies": [
         {
@@ -210,7 +210,7 @@
     ```bash
     aws iam create-access-key --user-name k0rdentUser 
     ```
-    ```console
+    ```console { .no-copy }
     {
       "AccessKey": {
         "UserName": "k0rdentUser",
@@ -348,7 +348,7 @@
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -365,14 +365,14 @@
     ```bash
     kubectl apply -f my-aws-clusterdeployment1.yaml
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com/my-aws-clusterdeployment1 created
     ```
     As before, there will be a delay as the cluster finishes provisioning. Follow the provisioning process with:
     ```bash
     kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-aws-clusterdeployment1 --watch
     ```
-    ```console
+    ```console { .no-copy }
     NAME                        READY   STATUS
     my-aws-clusterdeployment1   True    ClusterDeployment is ready
     ```

--- a/docs/admin/installation/prepare-mgmt-cluster/azure.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/azure.md
@@ -62,7 +62,7 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     ```bash
     az account list -o table
     ```
-    ```console
+    ```console { .no-copy }
     Name                     SubscriptionId                        TenantId
     -----------------------  -------------------------------------  --------------------------------
     My Azure Subscription    SUBSCRIPTION_ID_SUBSCRIPTION_ID        TENANT_ID_TENANT_ID_TENANT_ID
@@ -78,7 +78,7 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     ```bash
     az ad sp create-for-rbac --role contributor --scopes="/subscriptions/<SUBSCRIPTION_ID_SUBSCRIPTION_ID>"
     ```
-    ```console
+    ```console { .no-copy }
     {
     "appId": "SP_APP_ID_SP_APP_ID",
     "displayName": "azure-cli-2024-10-24-17-36-47",
@@ -145,7 +145,7 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     ```bash
     kubectl apply -f azure-cluster-identity.yaml
     ```
-    ```console
+    ```console { .no-copy }
     azureclusteridentity.infrastructure.cluster.x-k8s.io/azure-cluster-identity created
     ```
 
@@ -176,7 +176,7 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     ```bash
     kubectl apply -f azure-cluster-identity-cred.yaml
     ```
-    ```console
+    ```console { .no-copy }
     credential.k0rdent.mirantis.com/azure-cluster-identity-cred created
     ```
 
@@ -249,7 +249,7 @@ Standalone clusters can be deployed on Azure instances. Follow these steps to ma
     ```bash
     kubectl apply -f azure-cluster-identity-resource-template.yaml
     ```
-    ```console
+    ```console { .no-copy }
     configmap/azure-cluster-identity-resource-template created
     ```
 
@@ -264,7 +264,7 @@ Now you're ready to deploy the cluster.
     ```bash
     az account list-locations -o table
     ```
-    ```console
+    ```console { .no-copy }
     DisplayName               Name                 RegionalDisplayName
     ------------------------  -------------------  -------------------------------------
     East US                   eastus               (US) East US
@@ -285,7 +285,7 @@ Now you're ready to deploy the cluster.
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -324,7 +324,7 @@ Now you're ready to deploy the cluster.
     ```bash
     kubectl apply -f my-azure-clusterdeployment1.yaml
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com/my-azure-clusterdeployment1 created
     ```
 
@@ -352,13 +352,13 @@ Now you're ready to deploy the cluster.
     ```bash
     kubectl get clusterdeployments -A
     ```
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                          READY   STATUS
     kcm-system   my-azure-clusterdeployment1   True    ClusterDeployment is ready
     ```
     ```bash
     kubectl delete clusterdeployments my-azure-clusterdeployment1 -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com "my-azure-clusterdeployment1" deleted
     ```

--- a/docs/admin/installation/prepare-mgmt-cluster/gcp.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/gcp.md
@@ -132,7 +132,7 @@ Standalone clusters can be deployed on GCP instances. Follow these steps to make
 
     You should see output of:
 
-    ```console
+    ```console { .no-copy }
     credential.k0rdent.mirantis.com/gcp-cluster-identity-cred created
     ```
 
@@ -172,7 +172,7 @@ Standalone clusters can be deployed on GCP instances. Follow these steps to make
     ```bash
     kubectl apply -f gcp-cloud-sa-resource-template.yaml
     ```
-    ```console
+    ```console { .no-copy }
     configmap/gcp-cloud-sa-resource-template created
     ```
 
@@ -189,7 +189,7 @@ Now you're ready to deploy the cluster.
     
     You'll see output like this:
 
-    ```console
+    ```console { .no-copy }
     NAME                     CPUS    DISKS_GB  ADDRESSES  RESERVED_ADDRESSES  STATUS  TURNDOWN_DATE
     africa-south1            0/300   0/102400  0/575      0/175               UP
     asia-east1               0/3000  0/102400  0/575      0/175               UP
@@ -209,7 +209,7 @@ Now you're ready to deploy the cluster.
      ```bash
      kubectl get clustertemplate -n kcm-system
      ```
-     ```console
+     ```console { .no-copy }
      NAME                            VALID
      adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
      aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -256,7 +256,7 @@ Now you're ready to deploy the cluster.
      ```bash
      kubectl apply -f my-gcp-clusterdeployment1.yaml
      ```
-     ```console
+     ```console { .no-copy }
      clusterdeployment.k0rdent.mirantis.com/my-gcp-clusterdeployment1 created
      ```
 
@@ -281,13 +281,13 @@ Now you're ready to deploy the cluster.
     ```bash
     kubectl get clusterdeployments -A
     ```
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                          READY   STATUS
     kcm-system   my-gcp-clusterdeployment1   True    ClusterDeployment is ready
     ```
     ```bash
     kubectl delete clusterdeployments my-gcp-clusterdeployment1 -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com "my-gcp-clusterdeployment1" deleted
     ```

--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -186,7 +186,7 @@
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -270,13 +270,13 @@
     ```bash
     kubectl get clusterdeployments -A
     ```
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                          READY   STATUS
     kcm-system   my-openstack-cluster-deployment   True    ClusterDeployment is ready
     ```
     ```bash
     kubectl delete clusterdeployments my-openstack-cluster-deployment -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com "my-openstack-cluster-deployment" deleted
     ```

--- a/docs/admin/installation/prepare-mgmt-cluster/vmware.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/vmware.md
@@ -225,7 +225,7 @@ To enable users to deploy child clusers on vSphere, follow these steps:
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
-    ```console
+    ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
     aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true

--- a/docs/admin/installation/verify-install.md
+++ b/docs/admin/installation/verify-install.md
@@ -9,7 +9,7 @@ To understand whether installation is complete, start by making sure all pods ar
 kubectl get pods -n kcm-system
 ```
 
-```console
+```console { .no-copy }
 NAME                                                           READY   STATUS    RESTARTS   AGE
 azureserviceoperator-controller-manager-6b4dd86894-4dpfc       1/1     Running   0          7m15s
 capa-controller-manager-64bbcb9f8-ltj6z                        1/1     Running   0          6m58s
@@ -36,7 +36,7 @@ source-controller-74b597b995-kkqqw                             1/1     Running  
 kubectl get pods -n kcm-system --no-headers | wc -l
 ```
 
-```console
+```console { .no-copy }
 21
 ```
 
@@ -46,7 +46,7 @@ State management is handled by Project Sveltos, so you'll want to make sure that
 kubectl get pods -n projectsveltos
 ```
 
-```console
+```console { .no-copy }
 NAME                                      READY   STATUS    RESTARTS   AGE
 access-manager-6696df779-pnxjx            1/1     Running   0          10m
 addon-controller-6cb6c5f6df-zmfch         1/1     Running   0          10m
@@ -63,7 +63,7 @@ techsupport-controller-5b666d6884-jfqnp   1/1     Running   0          10m
 kubectl get pods -n projectsveltos --no-headers | wc -l
 ```
 
-```console
+```console { .no-copy }
 9
 ```
 
@@ -83,7 +83,7 @@ The actual measure of whether {{{ docsVersionInfo.k0rdentName }}} is ready is th
 kubectl get Management -n kcm-system
 ```
 
-```console
+```console { .no-copy }
 NAME   READY   RELEASE     AGE
 kcm    True    kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}}   9m
 ```
@@ -95,7 +95,7 @@ Next verify whether the KCM templates have been successfully installed and recon
 ```bash
 kubectl get providertemplate -n kcm-system
 ```
-```console
+```console { .no-copy }
 NAME                                   VALID
 cluster-api-{{{ extra.docsVersionInfo.providerVersions.dashVersions.clusterApi }}}                                 true
 cluster-api-provider-aws-{{{ docsVersionInfo.providerVersions.dashVersions.clusterApiProviderAws }}}                    true
@@ -120,7 +120,7 @@ You'll also want to make sure the `ClusterTemplate` objects are installed and va
 ```bash
 kubectl get clustertemplate -n kcm-system
 ```
-```console
+```console { .no-copy }
 NAME                             VALID
 adopted-cluster-{{{ docsVersionInfo.providerVersions.dashVersions.clusterApi }}}            true
 aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                    true
@@ -148,7 +148,7 @@ status of the `Management` object itself is `True`:
 ```bash
 kubectl get management -n kcm-system
 ```
-```console
+```console { .no-copy }
 NAME   READY   RELEASE         AGE
 kcm    True    kcm-{{{ docsVersionInfo.k0rdentVersion}}}   18m
 ```

--- a/docs/admin/ksm/ksm-multiclusterservice.md
+++ b/docs/admin/ksm/ksm-multiclusterservice.md
@@ -33,7 +33,7 @@ Command:
 ```bash
 kubectl get clusterdeployments.k0rdent.mirantis.com -n kcm-system
 ```
-```console
+```console { .no-copy }
 NAME             READY   STATUS
 dev-cluster-1   True    ClusterDeployment is ready
 dev-cluster-2   True    ClusterDeployment is ready
@@ -43,7 +43,7 @@ Command:
 ```bash
  kubectl get cluster -n kcm-system --show-labels
 ```
-```console
+```console { .no-copy }
 NAME           CLUSTERCLASS     PHASE         AGE     VERSION   LABELS
 dev-cluster-1                  Provisioned   2h41m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-1,helm.toolkit.fluxcd.io/namespace=kcm-system,sveltos-agent=present
 dev-cluster-2                  Provisioned   3h10m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=dev-cluster-2,helm.toolkit.fluxcd.io/namespace=kcm-system,sveltos-agent=present

--- a/docs/admin/upgrade/index.md
+++ b/docs/admin/upgrade/index.md
@@ -53,7 +53,7 @@ Upgrading {{{ docsVersionInfo.k0rdentName }}} involves making upgrades to the `M
     VERSION=v{{{ extra.docsVersionInfo.k0rdentDotVersion }}}
     kubectl create -f https://github.com/k0rdent/kcm/releases/download/${VERSION}/release.yaml
     ```
-    ```console
+    ```console { .no-copy }
     release.k0rdent.mirantis.com/kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}} created
     ```
 
@@ -65,7 +65,7 @@ Upgrading {{{ docsVersionInfo.k0rdentName }}} involves making upgrades to the `M
     kubectl get releases
     ```
 
-    ```console
+    ```console { .no-copy }
     NAME        AGE
     kcm-0-2-0   6d9h
     kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}}   12m
@@ -88,7 +88,7 @@ Upgrading {{{ docsVersionInfo.k0rdentName }}} involves making upgrades to the `M
     ```bash
     kubectl get managements.k0rdent.mirantis.com kcm
     ```
-    ```console
+    ```console { .no-copy }
     NAME   READY   RELEASE     AGE
     kcm    True    kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}}   4m34s
     ```

--- a/docs/contrib/k0rdent-documentation-contributors-guide.md
+++ b/docs/contrib/k0rdent-documentation-contributors-guide.md
@@ -18,7 +18,7 @@ Below you'll find [instructions for setting up MkDocs locally](#install-mkdocs-t
 
 The structure of {{{ docsVersionInfo.k0rdentName }}}/docs is shown below:
 
-```console
+```console { .no-copy }
 docs                                                # repository containing folder /docs
 ├── docs                                            # subdirectory for /docs, containing further subdirectories for assets, images, theme, etc.
 │   ├── assets                                      # illustrations for docs

--- a/docs/quickstarts/quickstart-1-mgmt-node-and-cluster.md
+++ b/docs/quickstarts/quickstart-1-mgmt-node-and-cluster.md
@@ -34,7 +34,7 @@ sudo k0s kubectl get nodes
 
 You should see something like this:
 
-```console
+```console { .no-copy }
 NAME              STATUS   ROLES    AGE   VERSION
 ip-172-31-29-61   Ready    <none>   46s   v1.31.2+k0s
 ```
@@ -72,7 +72,7 @@ kubectl get nodes
 
 You should see something like this:
 
-```console
+```console { .no-copy }
 NAME              STATUS   ROLES           AGE   VERSION
 ip-172-31-29-61   Ready    control-plane   25m   v1.31.2+k0s
 ```
@@ -89,7 +89,7 @@ chmod 700 get_helm.sh
 
 Issuing these commands should produce something very much like the following output:
 
-```console
+```console { .no-copy }
 Downloading https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz
 Verifying checksum... Done.
 Preparing to install helm into /usr/local/bin
@@ -103,7 +103,7 @@ Now we'll install {{{ docsVersionInfo.k0rdentName }}} itself into the k0s manage
 ```bash
 helm install kcm {{{ extra.docsVersionInfo.ociRegistry }}} --version {{{ extra.docsVersionInfo.k0rdentDotVersion }}} -n kcm-system --create-namespace
 ```
-```console
+```console { .no-copy }
 Pulled: ghcr.io/k0rdent/kcm/charts/kcm:{{{ extra.docsVersionInfo.k0rdentDotVersion }}}
 Digest: {{{ extra.docsVersionInfo.k0rdentDigestValue }}}
 NAME: kcm
@@ -126,7 +126,7 @@ kubectl get pods -n kcm-system   # check pods in the kcm-system namespace
 
 You should see something like:
 
-```console
+```console { .no-copy }
 NAME                                                           READY   STATUS
 azureserviceoperator-controller-manager-86d566cdbc-rqkt9       1/1     Running
 capa-controller-manager-7cd699df45-28hth                       1/1     Running
@@ -157,7 +157,7 @@ kubectl get pods -n projectsveltos   # check pods in the projectsveltos namespac
 
 You should see something like:
 
-```console
+```console { .no-copy }
 NAME                                     READY   STATUS    RESTARTS   AGE
 access-manager-cd49cffc9-c4q97           1/1     Running   0          16m
 addon-controller-64c7f69796-whw25        1/1     Running   0          16m
@@ -179,7 +179,7 @@ The actual measure of whether {{{ docsVersionInfo.k0rdentName }}} is ready is th
 ```bash
 kubectl get Management -n kcm-system
 ```
-```console
+```console { .no-copy }
 NAME   READY   RELEASE     AGE
 kcm    True    kcm-{{{ extra.docsVersionInfo.k0rdentVersion }}}   9m
 ```
@@ -194,7 +194,7 @@ kubectl get providertemplate -n kcm-system   # list providertemplate objects in 
 
 You should see output similar to:
 
-```console
+```console { .no-copy }
 NAME                                   VALID
 cluster-api-{{{ extra.docsVersionInfo.providerVersions.dashVersions.clusterApi }}}                                 true
 cluster-api-provider-aws-{{{ docsVersionInfo.providerVersions.dashVersions.clusterApiProviderAws }}}                    true
@@ -221,7 +221,7 @@ kubectl get clustertemplate -n kcm-system   # list clustertemplate objects in th
 
 You should see output similar to:
 
-```console
+```console { .no-copy }
 NAME                            VALID
 adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
 aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true

--- a/docs/quickstarts/quickstart-2-aws.md
+++ b/docs/quickstarts/quickstart-2-aws.md
@@ -69,7 +69,7 @@ USED=$(aws ec2 describe-addresses --query 'Addresses[*].PublicIp' --output text 
 AVAILABLE=$((LIMIT - USED))
 echo "Available Public IPs: $AVAILABLE"
 ```
-```console
+```console { .no-copy }
 Available Public IPs: 5
 ```
 
@@ -88,7 +88,7 @@ You can check on the status of your request:
 aws service-quotas list-requested-service-quota-change-history \
     --service-code ec2
 ```
-```console
+```console { .no-copy }
 {
     "RequestedQuotas": [
         {
@@ -118,7 +118,7 @@ Now we can use the AWS CLI to create a new {{{ docsVersionInfo.k0rdentName }}} u
 ```bash
  aws iam create-user --user-name k0rdentQuickstart
 ```
-```console
+```console { .no-copy }
 {
     "User": {
         "Path": "/",
@@ -171,7 +171,7 @@ aws iam list-attached-user-policies --user-name k0rdentQuickstart
 ```
 And you'll see output that looks like this (this is non-valid example text):
 
-```console
+```console { .no-copy }
 {
     "AttachedPolicies": [
         {
@@ -204,7 +204,7 @@ aws iam create-access-key --user-name k0rdentQuickstart
 
 You should see something like this. It's important to save these credentials securely somewhere other than the management node, since the management node may end up being ephemeral. Again, this is non-valid example text:
 
-```console
+```console { .no-copy }
 {
     "AccessKey": {
         "UserName": "k0rdentQuickstart",
@@ -336,7 +336,7 @@ kubectl get clustertemplate -n kcm-system
 
 You'll see output resembling what's below. Grab the name of the AWS standalone cluster template in its present version (in the below example, that's `aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}`):
 
-```console
+```console { .no-copy }
 NAMESPACE    NAME                            VALID
 kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
 kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -389,7 +389,7 @@ kubectl apply -f my-aws-clusterdeployment1.yaml
 
 Kubernetes should confirm this:
 
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com/my-aws-clusterdeployment1 created
 ```
 
@@ -401,7 +401,7 @@ kubectl -n kcm-system get clusterdeployment.k0rdent.mirantis.com my-aws-clusterd
 
 In a short while, you'll see output such as:
 
-```console
+```console { .no-copy }
 NAME                        READY   STATUS
 my-aws-clusterdeployment1   True    ClusterDeployment is ready
 ```
@@ -430,7 +430,7 @@ kubectl get ClusterDeployments -A
 
 You'll see output something like this:
 
-```console
+```console { .no-copy }
 NAMESPACE    NAME                        READY   STATUS
 kcm-system   my-aws-clusterdeployment1   True    ClusterDeployment is ready
 ```
@@ -445,7 +445,7 @@ kubectl delete ClusterDeployment my-aws-clusterdeployment1 -n kcm-system
 
 You'll see confirmation like this:
 
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com "my-aws-clusterdeployment1" deleted
 ```
 

--- a/docs/quickstarts/quickstart-2-azure.md
+++ b/docs/quickstarts/quickstart-2-azure.md
@@ -44,7 +44,7 @@ az provider list --query "[?registrationState=='Registered']" --output table
 
 And see a listing like this:
 
-```console
+```console { .no-copy }
 Namespace                             RegistrationState
 -----------------------------------   -----------------
 Microsoft.Compute                     Registered
@@ -71,7 +71,7 @@ az account list -o table
 
 The output will look like this:
 
-```console
+```console { .no-copy }
 Name                     SubscriptionId                    TenantId
 -----------------------  -------------------------------   -----------------------------
 My Azure Subscription    SUBSCRIPTION_ID_SUBSCRIPTION_ID   TENANT_ID_TENANT_ID_TENANT_ID
@@ -89,7 +89,7 @@ az ad sp create-for-rbac --role contributor --scopes="/subscriptions/<subscripti
 
 You'll see output that resembles what's below:
 
-```console
+```console { .no-copy }
 {
  "appId": "SP_APP_ID_SP_APP_ID",
  "displayName": "azure-cli-2024-10-24-17-36-47",
@@ -144,7 +144,7 @@ kubectl apply -f azure-cluster-identity-secret.yaml
 
 You should see output resembling this:
 
-```console
+```console { .no-copy }
 secret/azure-cluster-identity-secret created
 ```
 
@@ -184,7 +184,7 @@ kubectl apply -f azure-cluster-identity.yaml
 
 You should see output resembling this:
 
-```console
+```console { .no-copy }
 azureclusteridentity.infrastructure.cluster.x-k8s.io/azure-cluster-identity created
 ```
 
@@ -246,7 +246,7 @@ kubectl apply -f azure-cluster-identity-cred.yaml
 
 You should see output resembling this:
 
-```console
+```console { .no-copy }
 credential.k0rdent.mirantis.com/azure-cluster-identity-cred created
 ```
 
@@ -333,7 +333,7 @@ Apply the YAML to your cluster:
 ```bash
 kubectl apply -f azure-cluster-identity-resource-template.yaml
 ```
-```console
+```console { .no-copy }
 configmap/azure-cluster-identity-resource-template created
 ```
 
@@ -347,7 +347,7 @@ az account list-locations -o table
 
 You'll see output like this:
 
-```console
+```console { .no-copy }
 DisplayName               Name                 RegionalDisplayName
 ------------------------  -------------------  -------------------------------------
 East US                   eastus               (US) East US
@@ -370,7 +370,7 @@ kubectl get clustertemplate -n kcm-system
 
 You'll see output resembling what's below. Grab the name of the Azure standalone cluster template in its present version (in the example below, that's `azure-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.azureStandaloneCpCluster }}}`):
 
-```console
+```console { .no-copy }
 NAMESPACE    NAME                            VALID
 kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
 kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -445,7 +445,7 @@ kubectl apply -f my-azure-clusterdeployment1.yaml
 
 Kubernetes should confirm this:
 
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com/my-azure-clusterdeployment1 created
 ```
 
@@ -476,7 +476,7 @@ To verify the presence of the child cluster, list the available `ClusterDeployme
 ```bash
 kubectl get ClusterDeployments -A
 ```
-```console
+```console { .no-copy }
 NAMESPACE    NAME                          READY   STATUS
 kcm-system   my-azure-clusterdeployment1   True    ClusterDeployment is ready
 ```
@@ -488,7 +488,7 @@ To tear down the child cluster, delete the `ClusterDeployment`:
 ```bash
 kubectl delete ClusterDeployment my-azure-clusterdeployment1 -n kcm-system
 ```
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com "my-azure-clusterdeployment1" deleted
 ```
 

--- a/docs/quickstarts/quickstart-2-gcp.md
+++ b/docs/quickstarts/quickstart-2-gcp.md
@@ -101,7 +101,7 @@ kubectl apply -f gcp-cluster-identity-secret.yaml
 
 You should see output resembling this:
 
-```console
+```console { .no-copy }
 secret/gcp-cloud-sa created
 ```
 
@@ -131,7 +131,7 @@ kubectl apply -f gcp-credential.yaml
 
 You should see output resembling this:
 
-```console
+```console { .no-copy }
 credential.k0rdent.mirantis.com/gcp-credential created
 ```
 
@@ -171,7 +171,7 @@ Apply the YAML to your cluster:
 ```bash
 kubectl apply -f gcp-cloud-sa-resource-template.yaml
 ```
-```console
+```console { .no-copy }
 configmap/gcp-cloud-sa-resource-template created
 ```
 
@@ -185,7 +185,7 @@ gcloud compute regions list
 
 You'll see output like this:
 
-```console
+```console { .no-copy }
 NAME                     CPUS    DISKS_GB  ADDRESSES  RESERVED_ADDRESSES  STATUS  TURNDOWN_DATE
 africa-south1            0/300   0/102400  0/575      0/175               UP
 asia-east1               0/3000  0/102400  0/575      0/175               UP
@@ -224,7 +224,7 @@ gcloud compute images list --uri
 
 You'll see output like this:
 
-```console
+```console { .no-copy }
 https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-stream-9-arm64-v20250311
 https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-stream-9-v20250311
 https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-105-17412-535-84
@@ -247,7 +247,7 @@ kubectl get clustertemplate -n kcm-system
 
 You'll see output resembling what's below. Grab the name of the GCP standalone cluster template in its present version (in the example below, that's `gcp-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.gcpStandaloneCpCluster }}}`):
 
-```console
+```console { .no-copy }
 NAMESPACE    NAME                            VALID
 kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
 kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -338,7 +338,7 @@ kubectl apply -f my-gcp-clusterdeployment1.yaml
 
 Kubernetes should confirm this:
 
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com/my-gcp-clusterdeployment1 created
 ```
 
@@ -369,7 +369,7 @@ To verify the presence of the child cluster, list the available `ClusterDeployme
 ```bash
 kubectl get ClusterDeployments -A
 ```
-```console
+```console { .no-copy }
 NAMESPACE    NAME                          READY   STATUS
 kcm-system   my-gcp-clusterdeployment1   True    ClusterDeployment is ready
 ```
@@ -381,7 +381,7 @@ To tear down the child cluster, delete the `ClusterDeployment`:
 ```bash
 kubectl delete ClusterDeployment my-gcp-clusterdeployment1 -n kcm-system
 ```
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com "my-gcp-clusterdeployment1" deleted
 ```
 

--- a/docs/quickstarts/quickstart-2-remote.md
+++ b/docs/quickstarts/quickstart-2-remote.md
@@ -56,7 +56,7 @@ Apply the YAML to the {{{ docsVersionInfo.k0rdentName }}} management cluster:
 ```bash
 kubectl apply -f remote-ssh-key-secret.yaml
 ```
-```console
+```console { .no-copy }
 secret/remote-ssh-key created
 ```
 
@@ -86,7 +86,7 @@ Apply the YAML to your cluster:
 ```bash
 kubectl apply -f remote-cred.yaml
 ```
-```console
+```console { .no-copy }
 credential.k0rdent.mirantis.com/remote-cred created
 ```
 
@@ -125,7 +125,7 @@ kubectl get clustertemplate -n kcm-system
 
 You'll see output resembling the following. Make note of the name of the Remote Cluster template in its present version (in the example below, that's `remote-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.remoteCluster }}}`):
 
-```console
+```console { .no-copy }
 NAMESPACE    NAME                            VALID
 kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
 kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true
@@ -189,7 +189,7 @@ kubectl apply -f my-remote-clusterdeployment1.yaml
 
 Kubernetes should confirm the creation:
 
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com/my-remote-clusterdeployment1 created
 ```
 
@@ -207,7 +207,7 @@ kubectl -n kcm-system get remotemachines.infrastructure.cluster.x-k8s.io -l helm
 
 If the machines were provisioned, the output of this command will be similar to:
 
-```console
+```console { .no-copy }
 {"ready":true}{"ready":true}
 ```
 
@@ -234,7 +234,7 @@ To verify the presence of the child cluster, list the available `ClusterDeployme
 ```bash
 kubectl get ClusterDeployments -A
 ```
-```console
+```console { .no-copy }
 NAMESPACE    NAME                          READY   STATUS
 kcm-system   my-remote-clusterdeployment1   True    ClusterDeployment is ready
 ```
@@ -246,7 +246,7 @@ To tear down the child cluster, delete the `ClusterDeployment` from the manageme
 ```bash
 kubectl delete ClusterDeployment my-remote-clusterdeployment1 -n kcm-system
 ```
-```console
+```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com "my-remote-clusterdeployment1" deleted
 ```
 

--- a/docs/reference/template/template-byo.md
+++ b/docs/reference/template/template-byo.md
@@ -27,13 +27,13 @@ The source can be one of the following types:
 > To deploy kustomization using `ConfigMap` or `Secret` the kustomization folder must be archived in *.tar.gz and
 > then `ConfigMap` or `Secret` must be created from resulting archive:
 >
-> ```console
+> ```console { .no-copy }
 > kubectl create configmap foo --from-file=kustomization.tar.gz
 > ```
 >
 > To deploy raw resources using `ConfigMap` or `Secret` source object must be created from raw resource files:
 >
-> ```console
+> ```console { .no-copy }
 > kubectl create configmap bar --from-file=namespace.yaml --from-file=deployment.yaml
 > ```
 

--- a/docs/reference/template/template-predefined.md
+++ b/docs/reference/template/template-predefined.md
@@ -9,7 +9,7 @@ for `ClusterTemplate` objects, run:
     kubectl get clustertemplates -n kcm-system -l helm.toolkit.fluxcd.io/name=kcm-templates
     ```
 
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                            VALID
     kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
     kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true

--- a/docs/templatehowto/the-templating-system-common-threads.md
+++ b/docs/templatehowto/the-templating-system-common-threads.md
@@ -19,13 +19,13 @@ If you don't have one already, start by creating a **source object**. These obje
 
 To deploy a kustomization, archive the folder as `.tar.gz` and create a `ConfigMap` or `Secret` from the archive:
 
-```console
+```console { .no-copy }
 kubectl create configmap foo --from-file=kustomization.tar.gz
 ```
 
 To deploy raw resources, create a `ConfigMap` or `Secret` from the resource files:
 
-```console
+```console { .no-copy }
 kubectl create configmap bar --from-file=namespace.yaml --from-file=deployment.yaml
 ```
 

--- a/docs/user/services/checking-status.md
+++ b/docs/user/services/checking-status.md
@@ -54,7 +54,7 @@ You can check to see for yourself:
 ```bash
 kubectl get pod -n kyverno
 ```
-```console
+```console { .no-copy }
 NAME                                             READY   STATUS    RESTARTS   AGE
 kyverno-admission-controller-96c5d48b4-sg5ts     1/1     Running   0          2m39s
 kyverno-background-controller-65f9fd5859-tm2wm   1/1     Running   0          2m39s
@@ -64,7 +64,7 @@ kyverno-reports-controller-6f59fb8cd6-s8jc8      1/1     Running   0          2m
 ```bash
 kubectl get pod -n ingress-nginx 
 ```
-```console
+```console { .no-copy }
 NAME                                       READY   STATUS    RESTARTS   AGE
 ingress-nginx-controller-cbcf8bf58-zhvph   1/1     Running   0          24m
 ```

--- a/docs/user/user-create-cluster.md
+++ b/docs/user/user-create-cluster.md
@@ -64,7 +64,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     kubectl get clustertemplate -n kcm-system
     ```
 
-    ```console
+    ```console { .no-copy }
     NAMESPACE    NAME                            VALID
     kcm-system   adopted-cluster-{{{ extra.docsVersionInfo.providerVersions.dashVersions.adoptedCluster }}}           true
     kcm-system   aws-eks-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsEksCluster }}}                   true

--- a/docs/user/user-enable-drift-detection.md
+++ b/docs/user/user-enable-drift-detection.md
@@ -16,7 +16,7 @@ Set `.spec.serviceSpec.syncMode=Continuous` in the `ClusterDeployment` or `Multi
 ```sh
 kubectl -n projectsveltos get deployments.apps 
 ```
-```console
+```console { .no-copy }
 NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
 drift-detection-manager   1/1     1            1           152m
 sveltos-agent-manager     1/1     1            1           152m
@@ -54,7 +54,7 @@ If we manually remove the `app.kubernetes.io/managed-by=Helm` label, we can obse
 ```sh
 kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller --show-labels -w
 ```
-```console
+```console { .no-copy }
 NAME                       READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
 ingress-nginx-controller   3/3     3            3           3h58m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
 ingress-nginx-controller   3/3     3            3           3h59m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0


### PR DESCRIPTION
(cherry picked from commit 2ff97ee0fe3285ae6bc70d8dcebb5801463b5f5a)