### PR TITLE
docs: restore regions and migrate clusters

### DIFF
--- a/docs/admin/backup/caveats.md
+++ b/docs/admin/backup/caveats.md
@@ -3,7 +3,7 @@
 The credentials stored in backups can and will get stale,
 so a proper rotation should be considered beforehand.
 
-Only plugins that [support Object Store](https://velero.io/docs/v1.15/supported-providers/)
+Only plugins that [support Object Store](https://velero.io/docs/supported-providers/)
 can be used to store backups into an object storage.
 
 All `velero` caveats and limitations are transitively implied in {{{ docsVersionInfo.k0rdentName }}}. In particular, that
@@ -62,4 +62,4 @@ spec:
 > deletes it from both
 > the management cluster and from the cloud storage.
 
-For reference, follow the [official documentation](https://velero.io/docs/v1.15/backup-reference/#deleting-backups).
+For reference, follow the [official documentation](https://velero.io/docs/backup-reference/#deleting-backups).

--- a/docs/admin/backup/customization.md
+++ b/docs/admin/backup/customization.md
@@ -10,7 +10,7 @@ The [Velero helm chart](https://vmware-tanzu.github.io/helm-charts/) is supplied
 1. Install using `helm` and add corresponding parameters to the `helm install` command.
 
     > NOTE:
-    > Only a plugin that [supports Object Store](https://velero.io/docs/v1.15/supported-providers/)
+    > Only a plugin that [supports Object Store](https://velero.io/docs/supported-providers/)
     > is required during restoration; the other parameters are optional.
 
     For example, this command installs {{{ docsVersionInfo.k0rdentName }}} via `helm install` with a configured plugin, `BackupStorageLocation`
@@ -37,7 +37,7 @@ The [Velero helm chart](https://vmware-tanzu.github.io/helm-charts/) is supplied
 1. Create or modify the existing `Management` object in the `.spec.config.kcm`.
 
     > NOTE:
-    > Only a plugin that [supports Object Store](https://velero.io/docs/v1.15/supported-providers/)
+    > Only a plugin that [supports Object Store](https://velero.io/docs/supported-providers/)
     > is required during restoration; the other parameters are optional.
 
     For example, this is a `Management` object with a configured plugin and enabled metrics:

--- a/docs/admin/backup/ondemand-backups.md
+++ b/docs/admin/backup/ondemand-backups.md
@@ -2,26 +2,34 @@
 
 To create a single backup of the existing {{{ docsVersionInfo.k0rdentName }}} management cluster information, you can create a `ManagementBackup` object
 using a YAML document and the `kubectl` CLI. The object then creates only one instance of a backup. For example you can backup
-to the location created [previously](./prepare-backups.md). Create a YAML file called `one-time-backup.yaml`:
+to the location created [previously](./prepare-backups.md).
 
-```yaml
+> NOTE:
+> For the [regional cluster](../regional-clusters/index.md) case,
+> make sure to setup the same location on the regional cluster.
+
+Create a one time backup of your {{{ docsVersionInfo.k0rdentName }}} cluster by creating the following object:
+
+```sh
+kubectl create -f - <<EOF
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ManagementBackup
 metadata:
   name: example-backup
 spec:
   storageLocation: aws-s3
+EOF
 ```
-Create a one time backup of your {{{ docsVersionInfo.k0rdentName }}} cluster by applying the YAML to the cluster:
-```sh
-kubectl apply -f one-time-backup.yaml
-```
+
 Confirm the backup was successful by navigating to the appropriate storage console UI or from the command line:
+
 ```sh
-kubectl get managementbackup
+kubectl get managementbackups
 ```
+
 The `managementbackup` should show as `Completed`:
-```
+
+```console { .no-copy }
 NAME              LASTBACKUPSTATUS   NEXTBACKUP   AGE
 example-backup    Completed                       8m
 ```

--- a/docs/admin/backup/restore.md
+++ b/docs/admin/backup/restore.md
@@ -2,7 +2,7 @@
 
 > NOTE:
 > Please refer to the
-> [official migration documentation](https://velero.io/docs/v1.15/migration-case/#before-migrating-your-cluster)
+> [official migration documentation](https://velero.io/docs/migration-case/#before-migrating-your-cluster)
 > to familiarize yourself with potential limitations of the Velero backup system.
 
 In the event of disaster, you can restore from a backup by doing the following:
@@ -58,23 +58,134 @@ In the event of disaster, you can restore from a backup by doing the following:
     This ensures that the Velero `Deployment` name is exactly `velero`, which is a requirement due to the
     aforementioned known issue.
 
-1. Restore the `kcm` system creating the [`Restore`](https://velero.io/docs/v1.15/api-types/restore/) object.
-   Note that it is important to set the `.spec.existingResourcePolicy` field value to `update`:
+1. Restore the `kcm` system creating the [`Restore`](https://velero.io/docs/api-types/restore/) object.
+   Follow one of the case that is applicable to clusters' configuration in use:
 
-    ```yaml
-    apiVersion: velero.io/v1
-    kind: Restore
-    metadata:
-      name: <restore-name>
-      namespace: kcm-system
-    spec:
-      backupName: <backup-name>
-      existingResourcePolicy: update
-      includedNamespaces:
-      - '*'
-    ```
+    1. If there are **no** [regional clusters](../regional-clusters/index.md)
+        or all regional clusters' infrastructure is healthy.
+
+        Note that it is important to set the `.spec.existingResourcePolicy` field value to `update`.
+
+        ```yaml
+        apiVersion: velero.io/v1
+        kind: Restore
+        metadata:
+          name: <restore-name>
+          namespace: kcm-system
+        spec:
+          backupName: <backup-name>
+          existingResourcePolicy: update
+          includedNamespaces:
+          - '*'
+        ```
+
+    1. If one or more [regional clusters](../regional-clusters/index.md) require **reprovisioning**.
+
+        The following listing will create a `ConfigMap` object along with
+        the `Restore` object, and it allows `Velero` to set the
+        pause annotation to all of `regions` objects.
+
+        Substitute `<cluster-deployment-name>` with the corresponding
+        names of `ClusterDeployment` objects used for provisioning
+        of the corresponding region cluster.
+
+        Note that it is important to set the `.spec.existingResourcePolicy` field value to `update`.
+
+        ```yaml
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: add-region-pause-anno
+          namespace: kcm-system
+        data:
+          add-region-pause-anno: |
+            version: v1
+            resourceModifierRules:
+            - conditions:
+                groupResource: regions.k0rdent.mirantis.com
+              mergePatches:
+              - patchData: |
+                  {
+                    "metadata": {
+                      "annotations": {
+                        "k0rdent.mirantis.com/region-pause": "true"
+                      }
+                    }
+                  }
+        ---
+        apiVersion: velero.io/v1
+        kind: Restore
+        metadata:
+          name: <restore-name>
+          namespace: kcm-system
+        spec:
+          backupName: <backup-name>
+          existingResourcePolicy: update
+          includedNamespaces:
+          - '*'
+          labelSelector:
+            matchExpressions:
+              - key: cluster.x-k8s.io/cluster-name
+                operator: NotIn
+                values: ["<cluster-deployment-name>"]
+              # Add new entries accordingly if more regional clusters require reprovisioning
+              # - key: cluster.x-k8s.io/cluster-name
+              #   operator: NotIn
+              #   values: ["<cluster-deployment-name>"]
+          resourceModifier:
+            kind: ConfigMap
+            name: add-region-pause-anno
+        ```
 
 1. Wait until the `Restore` status is `Completed` and all `kcm` components are up and running.
+
+1. If there were one or more [regional clusters](../regional-clusters/index.md)
+   that required reprovisioning, then:
+
+    1. On the management cluster, wait for the `regions` object readiness:
+
+        ```sh
+        kubectl wait regions kcm --for=condition=Ready=True --timeout 30m
+        ```
+
+    1. Manually ensure that the freshly reprovisioned regional cluster
+        runs and is accessable.
+
+    1. On the **regional** cluster, repeat the second step, creating the
+        `BackupStorageLocation`/`Secret` objects that were created during
+        the [preparation stage](./prepare-backups.md).
+
+    1. On the **regional** cluster, restore the cluster by creating a new
+        [`Restore`](https://velero.io/docs/api-types/restore/) object:
+
+        Note that in this case the `.spec.existingResourcePolicy` field is **not set**.
+
+        ```yaml
+        apiVersion: velero.io/v1
+        kind: Restore
+        metadata:
+          name: <restore-name>
+          namespace: kcm-system
+        spec:
+          backupName: <region-name>-<backup-name>
+          excludedResources:
+          - mutatingwebhookconfiguration.admissionregistration.k8s.io
+          - validatingwebhookconfiguration.admissionregistration.k8s.io
+          includedNamespaces:
+          - '*'
+        ```
+
+    1. On the **regional** cluster, wait until the `Restore`
+        status is `Completed` and all `ClusterDeployment` objects are ready.
+
+    1. On the management cluster, unpause provisioning of
+        regional `ClusterDeployment` objects by removing annotation
+        from the `regions` object:
+
+        ```sh
+        kubectl annotate regions <region-name> 'k0rdent.mirantis.com/region-pause-'
+        ```
 
 ## Caveats
 
@@ -86,6 +197,11 @@ default to avoid logical dependencies on one or another provider, and to create 
 > NOTE:
 > The described caveats apply only to the `Restore`
 > object creation step and do not affect the other steps.
+
+> NOTE:
+> The below mentioned exclusions (`excludedResources`)
+> are applicable to any of the `Restore` examples on
+> this page, including those tailored for [regional clusters](../regional-clusters/index.md).
 
 ### Azure (CAPZ)
 
@@ -128,7 +244,7 @@ The following resources should be excluded from the `Restore` object:
 * `mutatingwebhookconfiguration.admissionregistration.k8s.io`
 * `validatingwebhookconfiguration.admissionregistration.k8s.io`
 
-Due to the [Velero Restoration Order](https://velero.io/docs/v1.15/restore-reference/#restore-order),
+Due to the [Velero Restoration Order](https://velero.io/docs/restore-reference/#restore-order),
 some of the `CAPV` core objects cannot be restored,
 and they will not be recreated automatically.
 Because all of the objects have already passed both mutations

--- a/docs/admin/backup/scheduled-backups.md
+++ b/docs/admin/backup/scheduled-backups.md
@@ -11,11 +11,18 @@ If the `.spec.schedule` field is not set, a [backup on demand](./ondemand-backup
 Optionally, set the name of the `.spec.backup.storageLocation` of the `BackupStorageLocation` object.
 The default location is the `BackupStorageLocation` object with `.spec.default` set to `true`.
 
+> NOTE:
+> For the [regional cluster](../regional-clusters/index.md) case,
+> make sure to [setup](./prepare-backups.md) the same location on the regional cluster.
+
 For example, you can create a `ManagementBackup` object that backs up to the storage object
 created in the [preparation step](./prepare-backups.md) every 6 hours
-(ref: [Kubernetes CronJob schedule syntax, "Vixie cron" step values](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax)). Create a YAML file called `scheduled-backup.yaml`:
+(ref: [Kubernetes CronJob schedule syntax, "Vixie cron" step values](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax)).
 
-```yaml
+Start the scheduled backup process by creating the following object:
+
+```sh
+kubectl apply -f - <<EOF
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ManagementBackup
 metadata:
@@ -25,15 +32,15 @@ spec:
   storageLocation: aws-s3
 EOF
 ```
-Start the scheduled backup process by applying the YAML to the cluster:
-```sh
-kubectl apply -f scheduled-backup.yaml
-```
+
 Confirm the backup creation was successful by navigating to the appropriate storage console UI or from the command line:
+
 ```sh
-kubectl get managementbackup
+kubectl get managementbackups
 ```
+
 The `managementbackup` should show as `Completed`:
+
 ```console { .no-copy }
 NAME              LASTBACKUPSTATUS   NEXTBACKUP   AGE
 example-backup    Completed                       8m  

--- a/docs/admin/clusters/migration.md
+++ b/docs/admin/clusters/migration.md
@@ -1,0 +1,148 @@
+# Migrate `ClusterDeployment` from one management cluster to another
+
+This guide provides instructions for migrating a `ClusterDeployment`
+resource from one {{{ docsVersionInfo.k0rdentName }}} management cluster to another.
+This process uses [Velero](https://velero.io/) for backup and restore operations
+between the clusters.
+
+## Prerequisites
+
+Before beginning the migration process, ensure you have:
+
+1. Access to both source and target management clusters with admin permissions.
+1. `kubectl` configured to access both clusters.
+1. Velero properly installed and configured on both clusters (see [Preparing for Backups](../backup/prepare-backups.md)).
+
+## Prepare your clusters
+
+1. **Source Cluster**: Prepare your source cluster for backups by following the instructions
+   in [Preparing for Backups](../backup/prepare-backups.md).
+1. **Target Cluster**: Similarly, prepare your target cluster with the same Velero
+   configuration using **the same backup storage location**.
+
+## Migration Steps
+
+### 1. Backup the ClusterDeployment from the source cluster
+
+```sh
+# Switch context to source cluster
+kubectl config use-context <source-cluster-context>
+# Or set the source config
+export KUBECONFIG="<path-to-source-cluster-kubeconfig>"
+
+# Create a backup
+CLD="<cluster-deployment-name>"
+BSL="<storage-location-name>"
+TPL="$(kubectl -n <cld-namespace> get clusterdeployments "$CLD" -o go-template='{{.spec.template}}')"
+
+{
+  cat <<EOF
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: cld-migration
+  namespace: kcm-system
+spec:
+  storageLocation: $BSL
+  includedNamespaces:
+  - '*'
+  orLabelSelectors:
+  - matchLabels:
+      k0rdent.mirantis.com/component: kcm
+  - matchLabels:
+      cluster.x-k8s.io/provider: cluster-api
+  - matchLabels:
+      controller.cert-manager.io/fao: "true"
+  - matchLabels:
+      helm.toolkit.fluxcd.io/name: $CLD
+  - matchLabels:
+      cluster.x-k8s.io/cluster-name: $CLD
+EOF
+
+  kubectl -n <cluster-template-namespace> get clustertemplates "$TPL" \
+    -o go-template='{{range .status.providers}}{{if ne . "cluster-api"}}{{printf "  - matchLabels:\n      cluster.x-k8s.io/provider: %s\n" .}}{{end}}{{end}}'
+} | kubectl create -f -
+
+
+# Verify backup completion
+kubectl -n kcm-system wait backups.velero.io cld-migration \
+    --for=jsonpath='{.status.phase}'='Completed' \
+    --timeout 10m
+```
+
+### 2. Prepare the target Management cluster
+
+```sh
+# Switch context to target cluster
+kubectl config use-context <target-cluster-context>
+# Or set the target config
+export KUBECONFIG="<path-to-target-cluster-kubeconfig>"
+
+# Verify Velero and BackupStorageLocation are properly configured
+kubectl -n kcm-system get backupstoragelocation
+```
+
+### 3. Restore the ClusterDeployment to the target cluster
+
+```sh
+# Disable admission validating webhook
+kubectl patch managements kcm --type=merge \
+    --patch='{"spec":{"core":{"kcm":{"config":{"admissionWebhook":{"enabled": false}}}}}}'
+
+# Wait the management cluster to be reconfigured
+kubectl wait management kcm --for=condition=Ready=True --timeout 10m
+
+# Verify the backups synced from the backup storage location
+kubectl -n kcm-system get backups.velero.io
+
+# Create a restore operation on the target cluster
+kubectl create -f - <<EOF
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: restore-cld-migration
+  namespace: kcm-system
+spec:
+  backupName: cld-migration
+  includedNamespaces:
+  - '*'
+  restoreStatus:
+    includedResources:
+    - '*'
+  excludedResources:
+  - mutatingwebhookconfiguration.admissionregistration.k8s.io
+  - validatingwebhookconfiguration.admissionregistration.k8s.io
+EOF
+
+# Wait for the restore process successful completion
+kubectl -n kcm-system wait restores.velero.io restore-cld-migration \
+    --for=jsonpath='{.status.phase}'='Completed' \
+    --timeout 10m
+
+# Enable admission validating webhook back (if it was enabled initially)
+kubectl patch managements kcm --type=merge \
+    --patch='{"spec":{"core":{"kcm":{"config":{"admissionWebhook":{"enabled": true}}}}}}'
+```
+
+### 4. Verify the migration
+
+```sh
+# Verify the ClusterDeployment exists on the target cluster
+kubectl -n <cld-namespace> get clusterdeployments <cluster-deployment-name>
+
+# Check cluster status
+kubectl -n <cld-namespace> describe clusterdeployments <cluster-deployment-name>
+```
+
+## Troubleshooting
+
+- **Backup fails**: Ensure Velero is properly configured and has access to
+    the storage location. Check Velero logs for specific errors.
+- **Restore fails**: Verify that the target cluster can access the backup
+    storage location and has the necessary permissions.
+- **Resource conflicts**: If resources already exist in the target cluster,
+    you may need to delete them first or use the
+    `existingResourcePolicy: update` option in your `Restore`.
+
+For more detailed information on using Velero for backups and restores,
+refer to the [official Velero documentation](https://velero.io/docs/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
       - Updating standalone clusters: admin/clusters/update-cluster.md
       - Adopting clusters: admin/clusters/admin-adopting-clusters.md
       - IP Address Management (IPAM): admin/clusters/cluster-ipam.md
+      - Migrate ClusterDeployment: admin/clusters/migration.md
     - Working with regional clusters:
       - Overview: admin/regional-clusters/index.md
       - Regional Components Segregation Overview: admin/regional-clusters/components-segregation.md


### PR DESCRIPTION
Adds a doc page with an instruction on how to migrate a cluster deployment object from one mgmt cluster to another one.

Adds regions-related information to the existing backup docs, including preparation docs, backup and restoration instructions and examples.

Fixes several typos/incorrect phrases wrt the existing backup docs.

Updates velero docs version to use the latest (unversioned) docs.

Closes k0rdent/2a-internal#267
Closes #585 