### PR TITLE
fix: proper allowedNamespaces in aws cluster identity examples

### DIFF
--- a/docs/admin/installation/prepare-mgmt-cluster/aws.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/aws.md
@@ -325,9 +325,7 @@ Now go ahead and prepare the cluster.
         k0rdent.mirantis.com/component: "kcm"
     spec:
       secretRef: aws-cluster-identity-secret
-      allowedNamespaces:
-        selector:
-          matchLabels: {}
+      allowedNamespaces: {}
     ```
 
     Notice that the `secretRef` references the `Secret` you created in the previous step.

--- a/docs/admin/regional-clusters/creating-credential-in-region.md
+++ b/docs/admin/regional-clusters/creating-credential-in-region.md
@@ -70,9 +70,7 @@ with the cloud.
        k0rdent.mirantis.com/component: "kcm"
    spec:
      secretRef: aws-cluster-identity-secret
-     allowedNamespaces:
-       selector:
-         matchLabels: {}
+     allowedNamespaces: {}
    ```
 
    Notice that the `secretRef` references the `Secret` you created in the previous step.

--- a/docs/quickstarts/quickstart-2-aws.md
+++ b/docs/quickstarts/quickstart-2-aws.md
@@ -267,9 +267,7 @@ metadata:
     k0rdent.mirantis.com/component: "kcm"
 spec:
   secretRef: aws-cluster-identity-secret
-  allowedNamespaces:
-    selector:
-      matchLabels: {}
+  allowedNamespaces: {}
 ```
 
 Note that the `spec.secretRef` is the same as the `metadata.name` of the secret we just created.


### PR DESCRIPTION
Fix invalid aws cluster identity examples.
Ref: https://github.com/k0rdent/kcm/issues/2022