### PR TITLE
KOF 1.5.0 Missing istio-gateway and few more fixes

### DIFF
--- a/docs/admin/kof/kof-alerts.md
+++ b/docs/admin/kof/kof-alerts.md
@@ -1,5 +1,7 @@
 # KOF Alerts
 
+## Summary
+
 At this point you have metrics collected and visualized. It is important to check them manually,
 but it is even better to **automate detection and notification about the issues found in the data.**
 

--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -422,6 +422,7 @@ and apply this example for AWS, or use it as a reference:
       with:
       ```yaml
       k0rdent.mirantis.com/istio-role: member
+      k0rdent.mirantis.com/istio-gateway: "true"
       ```
       
     * Delete these lines:

--- a/docs/admin/kof/kof-kcm-region.md
+++ b/docs/admin/kof/kof-kcm-region.md
@@ -57,7 +57,7 @@ k0rdent.mirantis.com/istio-role: member
 ```
 
 > NOTE:
-> The `k0rdent.mirantis.com/istio-mesh` label allows propagating `remote secrets` only to clusters that have this label. If this label is not set, remote secrets will be propagated across all regions.
+> The `k0rdent.mirantis.com/istio-mesh` label allows propagating `remote secrets` only to clusters that have this label. This label is required.
 
 > NOTE:
 > To enable connectivity between a child cluster and the regional cluster, set the `k0rdent.mirantis.com/istio-mesh` label with the same `<REGION_NAME>` value on both clusters.

--- a/docs/admin/regional-clusters/creating-credential-in-region.md
+++ b/docs/admin/regional-clusters/creating-credential-in-region.md
@@ -124,16 +124,16 @@ The `spec.region` should be configured and refer the name of the `Region` object
 ```yaml
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: Credential
-  metadata:
-    name: aws-cluster-identity-cred
-    namespace: kcm-system
-  spec:
-    region: region1
-    description: "Credential Example"
-    identityRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: AWSClusterStaticIdentity
-      name: aws-cluster-identity
+metadata:
+  name: aws-cluster-identity-cred
+  namespace: kcm-system
+spec:
+  region: region1
+  description: Credential for child clusters of region1
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSClusterStaticIdentity
+    name: aws-cluster-identity
 ```
 
 Apply the YAML to your management cluster:


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/603 and https://github.com/k0rdent/istio/issues/17
* This PR fixes critical line lost during "replacement" of KOF 1.5.0 docs,
and also fixes few more things related to this release of KCM and KOF.

Steps applied to find what is missing:
* Found the list of KOF 1.5.0 PRs in https://github.com/k0rdent/docs/pulls?q=is%3Apr+is%3Aclosed
  looking to authors, not just title of PR, as some don't mention KOF at all.
* For each such PR:
    * Found the line like `merged commit 2da6ab9 into k0rdent:main on Oct 6` in the end of PR.
    * Right-click `Oct 6` - Inspect - double-click `2025-10-06T13:35:23Z` - copy.
    * Added `2025-10-06T13:35:23Z - 2da6ab9 - ` before this PR in the list.
* Sorted this list with my editor, `cat list.txt | sort` works too.
* Resulting list:
  * 2025-10-06T13:35:23Z - 2da6ab9 - https://github.com/k0rdent/docs/pull/580
  * 2025-10-24T23:45:36Z - ae13363 - https://github.com/k0rdent/docs/pull/582
  * 2025-10-25T03:47:13Z - 6e53424 - https://github.com/k0rdent/docs/pull/586
  * 2025-10-28T02:29:13Z - 0aa6fd9 - https://github.com/k0rdent/docs/pull/594
  * 2025-10-30T01:39:57Z - a629f9c - https://github.com/k0rdent/docs/pull/599
  * 2025-10-30T01:41:20Z - 40cbbca - https://github.com/k0rdent/docs/pull/598
  * 2025-10-30T01:58:11Z - 236bd7a - https://github.com/k0rdent/docs/pull/587
  * 2025-11-02T01:02:54Z - 821f22a - https://github.com/k0rdent/docs/pull/602
  * 2025-11-06T15:17:26Z - 03f451d - https://github.com/k0rdent/docs/pull/603
  * 2025-11-06T20:34:43Z - c021d3c - https://github.com/k0rdent/docs/pull/609
  * 2025-11-07T17:02:14Z - 11be5f4 - https://github.com/k0rdent/docs/pull/611
  * 2025-11-07T17:02:50Z - e21ac06 - https://github.com/k0rdent/docs/pull/612
  * 2025-11-07T17:03:49Z - 785439d - https://github.com/k0rdent/docs/pull/613
* Note e.g. 599 was merged before 598 and 587, so precise timestamps are critical.
* Found the base (parent 1) of the oldest merge commit and created a branch from it:
  ```
  git show 2da6ab9

    Merge: e810d8c 4d48f53

  git checkout -b kof-1-5-0-combined e810d8c
  ```
* Cherry-picked all merge commits from oldest to newest,
  indicating that the parent 1 is the mainline (closer to main):
  ```
  git cherry-pick -m 1 2da6ab9
  git cherry-pick -m 1 ae13363
  ...
  ```
* Got few minor git conflicts, resolved them, `git add . && git cherry-pick --continue`
* Copied the resulting "expected" versions of the files to `/tmp/ok` dir.
* `git checkout main` and copied files back.
* `git diff` has shown the missing `istio-gateway` and few minor changes.
