### PR TITLE
Add Identity and Authorization Management docs

### DIFF
--- a/docs/admin/access/accessmanagement.md
+++ b/docs/admin/access/accessmanagement.md
@@ -1,0 +1,72 @@
+# Access Management Resource
+
+{{{ docsVersionInfo.k0rdentName }}} provides an `AccessManagement` resource (cluster-scoped, singleton) that
+enables controlled distribution of multiple object types (`ClusterTemplate`, `ServiceTemplate`, `Credential`, and
+`ClusterAuthentication`) from the system namespace (default: `kcm-system`) across other namespaces in the management
+cluster. This resource is created automatically during the installation of {{{ docsVersionInfo.k0rdentName }}}.
+
+## Supported Configuration Options
+
+* `spec.accessRules` - A list of access rules that define how specific objects should be distributed.
+
+Each access rule supports the following fields:
+
+* `targetNamespaces` - Determines which namespaces selected objects should be distributed to.
+If omitted, objects are distributed to all namespaces.
+
+> Only one of the following mutually-exclusive selectors may be used:
+>
+> * `targetNamespaces.stringSelector` - A label query to select namespaces (type: `string`).
+> * `targetNamespaces.selector` - A structured label query to select namespaces (type: `metav1.LabelSelector`)
+> * `targetNamespaces.list` - The list of namespaces to select (type: `[]string`).
+
+* `clusterTemplateChains` - The list of `ClusterTemplateChain` names whose ClusterTemplates will be distributed
+to all namespaces specified in `targetNamespaces`.
+
+* `serviceTemplateChains` - The list of `ServiceTemplateChain` names whose ServiceTemplates will be distributed
+  to all namespaces specified in `targetNamespaces`.
+
+* `credentials` - The list of `Credential` names that will be distributed to all the namespaces specified in
+`targetNamespaces`.
+
+* `clusterAuthentications` - The list of `ClusterAuthentication` names that will be distributed to all the namespaces
+specified in `targetNamespaces`.
+
+## Example: AccessManagement
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: AccessManagement
+metadata:
+  labels:
+    k0rdent.mirantis.com/component: kcm
+  name: kcm
+spec:
+  accessRules:
+  - targetNamespaces:
+      list:
+      - namespace1
+      - namespace2
+    clusterTemplateChains:
+    - ct-chain1
+    serviceTemplateChains:
+    - st-chain1
+    credentials:
+    - cred1
+  - targetNamespaces:
+      list:
+      - namespace3
+    clusterAuthentications:
+    - auth1
+```
+
+For the example above the following objects will be distributed following these rules:
+
+1. All ClusterTemplates referenced by ClusterTemplateChain `ct-chain1` are distributed to `namespace1` and `namespace2`.
+2. All ServiceTemplates referenced by ServiceTemplateChain `st-chain1` are distributed to `namespace1` and `namespace2`.
+3. The Credential `cred1` and all referenced Identity resources are distributed to `namespace1` and `namespace2`.
+4. The ClusterAuthentication `auth1` and its referenced CA secret are distributed to `namespace3`.
+
+See [Credential Distribution System](credentials/credentials-propagation.md#the-credential-distribution-system)
+and [Template Life Cycle Management](../../reference/template/index.md#template-life-cycle-management) for more details
+about distributing `Credential`, `ClusterTemplate` and `ServiceTemplate` objects.

--- a/docs/admin/access/index.md
+++ b/docs/admin/access/index.md
@@ -6,3 +6,4 @@ cluster to control access to specific services or other Kubernetes resources.
 
 - [{{{ docsVersionInfo.k0rdentName }}} Credentials Management](credentials/index.md)
 - [{{{ docsVersionInfo.k0rdentName }}} Role Based Access Control (RBAC)](rbac/index.md)
+- [{{{ docsVersionInfo.k0rdentName }}} Access Management](accessmanagement.md)

--- a/docs/admin/access/rbac/index.md
+++ b/docs/admin/access/rbac/index.md
@@ -4,4 +4,5 @@
 
 - [What Roles Do](what-roles-do.md)
 - [Role Definitions](roles-summary.md)
+- [Roles Management](roles-management.md)
 - [Limiting Access](limiting-access.md)

--- a/docs/admin/access/rbac/roles-management.md
+++ b/docs/admin/access/rbac/roles-management.md
@@ -1,0 +1,77 @@
+# Roles Management
+
+{{{ docsVersionInfo.k0rdentName }}} now includes the [Fairwinds RBAC Manager](https://rbac-manager.docs.fairwinds.com/)
+as part of the management cluster.
+
+The RBAC Manager is an operator that simplifies Kubernetes authorization.
+Instead of manually creating Roles, ClusterRoles, RoleBindings, ClusterRoleBindings, or ServiceAccounts, you
+declare the desired state using a `RBACDefinition` custom resource. RBAC Manager then automatically creates
+and maintains the required RBAC objects.
+
+## Usage Example
+
+```yaml
+apiVersion: rbacmanager.reactiveops.io/v1beta1
+kind: RBACDefinition
+metadata:
+  name: rbac-manager-example
+rbacBindings:
+  - name: cluster-admins
+    subjects:
+      - kind: User
+        name: kate@example.com
+    clusterRoleBindings:
+      - clusterRole: kcm-global-admin-role
+  - name: backend-developers
+    subjects:
+      - kind: User
+        name: michael@example.com
+      - kind: User
+        name: alexey@example.com
+    roleBindings:
+      - clusterRole: kcm-namespace-admin-role
+        namespace: dev
+      - clusterRole: kcm-namespace-viewer-role
+        namespace: test
+  - name: testers
+    subjects:
+      - kind: User
+        name: jack@example.com
+    roleBindings:
+      - clusterRole: kcm-namespace-admin-role
+        namespace: test
+  - name: ci-bot
+    subjects:
+      - kind: ServiceAccount
+        name: ci-bot
+        namespace: kcm-system
+    roleBindings:
+      - clusterRole: edit
+        namespaceSelector:
+          matchExpressions:
+            - key: name
+              operator: In
+              values:
+                - projectsveltos
+                - kcm-system
+```
+
+From the example above, RBAC Manager will generate:
+
+1. `ClusterRoleBinding` granting Kate the `kcm-global-admin-role`, providing full administrative access across
+the entire {{{ docsVersionInfo.k0rdentName }}} system.
+2. `RoleBinding` that gives Michael and Alexey `kcm-namespace-admin-role` with full administrative access across
+the `dev` namespace and `kcm-namespace-viewer-role` with read-only access in the `test` namespace.
+3. `RoleBinding` granting Jack `kcm-namespace-admin-role` in the `test` namespace.
+4. A `ServiceAccount` named `ci-bot` in the `kcm-system` namespace.
+5. `RoleBindings` that grant the `ci-bot` ServiceAccount `edit` access in `projectsveltos` and `kcm-system` namespaces
+using namespace selector.
+
+See [RBACDefinition Examples](https://github.com/FairwindsOps/rbac-manager/tree/master/examples) for more examples of
+the `RBACDefinition` resource.
+
+> NOTE:
+> The names of the `ClusterRole` objects may have different prefixes depending on the name of the {{{ docsVersionInfo.k0rdentName }}} Helm chart.
+> The `ClusterRole` object definitions below use the `kcm` prefix, which is the default name of the {{{ docsVersionInfo.k0rdentName }}} Helm chart.
+
+See [Roles Summary](roles-summary.md) for more details about standard {{{ docsVersionInfo.k0rdentName }}} roles.

--- a/docs/admin/clusters/cluster-iam-setup.md
+++ b/docs/admin/clusters/cluster-iam-setup.md
@@ -1,0 +1,166 @@
+# Identity And Authorization Management
+
+## ClusterAuthentication Resource
+
+{{{ docsVersionInfo.k0rdentName }}} supports configuring identity and authorization management (IAM) for
+child clusters through the `ClusterAuthentication` custom resource. A `ClusterAuthentication` object
+defines how the Kubernetes API server authenticates incoming requests. It supports multiple JWT authenticators,
+each configurable with an issuer URL, claim mappings, certificate authorities, and more.
+
+The `ClusterAuthentication` object example:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterAuthentication
+metadata:
+  name: dex-cluster-auth
+  namespace: kcm-system
+spec:
+  authenticationConfiguration:
+    apiVersion: apiserver.config.k8s.io/v1beta1
+    kind: AuthenticationConfiguration
+    jwt:
+      - issuer:
+          url: https://dex.example.com:5556
+          audiences:
+            - example-app
+        claimMappings:
+          username:
+            claim: email
+            prefix: ""
+          groups:
+            claim: groups
+            prefix: ""
+        userValidationRules:
+          - expression: "!user.username.startsWith('system:')"
+            message: "username cannot use reserved system: prefix"
+  caSecret:
+    name: dex-ca-secret
+    namespace: kcm-system
+    key: ca.crt
+```
+
+### Supported Fields
+
+* `spec.authenticationConfiguration`
+
+Contains the full `AuthenticationConfiguration` object used by the API server. For all available configuration
+options, see the official Kubernetes documentation:
+[Authentication configuration from a file](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration).
+
+* `spec.caSecret`
+
+References a Kubernetes Secret that contains one or more CA certificates for the JWT issuer endpoint.
+If the issuer uses a custom or self-signed CA, the certificate must be provided here so the API server can trust the issuer.
+The CA value is injected into the `AuthenticationConfiguration` under `jwt.issuer[*].certificateAuthority`.
+
+## Configuring Authentication for ClusterDeployments
+
+To enable authentication for a `ClusterDeployment`, set the `spec.clusterAuth` field to the name of an existing
+`ClusterAuthentication` object in the same namespace. For example:
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: cluster-name
+  namespace: kcm-system
+spec:
+  template: openstack-hosted-cp-1-0-12
+  credential: openstack-cluster-identity-cred
+  clusterAuth: dex-cluster-auth
+```
+
+> NOTE:
+> `ClusterAuthentication` objects can be distributed across namespaces using `AccessManagement` resource.
+> See [Access Management Resource](../access/accessmanagement.md) for details.
+
+## Integration with ClusterTemplates
+
+When `spec.clusterAuth` is configured in the `ClusterDeployment` and the referenced `ClusterAuthentication` exists,
+the {{{ docsVersionInfo.k0rdentName }}} KCM controller performs the following:
+
+1. Generates a Secret named `<cluster-deployment-name>-auth-config` that contains the merged
+`AuthenticationConfiguration` (including injected CA certificates).
+
+2. Passes required authentication values to the HelmRelease responsible for deploying the cluster:
+
+```yaml
+    auth:
+      configSecret:
+        name: cluster-name-auth-config
+        key: config
+        hash: 3f7b8627
+```
+
+* `auth.configSecret.name` - Name of the Secret containing the authentication config.
+* `auth.configSecret.key` - Key within the Secret where the configuration is stored.
+* `auth.configSecret.hash` - Hash of the configuration content; used to trigger control plane updates when changed.
+
+ClusterTemplate must consume these values to configure the API server correctly.
+In particular, the control plane resources (`K0smotronControlPlane` or `K0sControlPlane`) must:
+
+1. Mount the authentication Secret on control plane nodes/pods, and
+2. Set the API server’s `--authentication-configuration` flag.
+
+### Example: `K0smotronControlPlane` Authentication Configuration
+
+```yaml
+spec:
+  k0sConfig:
+    apiVersion: k0s.k0sproject.io/v1beta1
+    kind: ClusterConfig
+    metadata:
+      name: k0s
+    spec:
+      mounts:
+      {{- if .Values.auth.configSecret.name }}
+      - path: /var/lib/k0s/auth
+        secret:
+          defaultMode: 420
+          items:
+            - key: {{ .Values.auth.configSecret.key }}
+              path: config-{{ .Values.auth.configSecret.hash }}.yaml
+          secretName: {{ .Values.auth.configSecret.name }}
+      {{- end }}
+      ...
+      api:
+        extraArgs:
+          {{- if .Values.auth.configSecret.name }}
+          authentication-config: /var/lib/k0s/auth/config-{{ .Values.auth.configSecret.hash }}.yaml
+          {{- end }}
+      ...
+```
+
+### Example: `K0sControlPlane` Authentication Configuration
+
+```yaml
+spec:
+  k0sConfigSpec:
+    {{- if .Values.auth.configSecret.name }}
+    files:
+    - contentFrom:
+        secretRef:
+          name: {{ .Values.auth.configSecret.name }}
+          key: {{ default "config" .Values.auth.configSecret.key }}
+      permissions: "0644"
+      path: /var/lib/k0s/auth/config-{{ .Values.auth.configSecret.hash }}.yaml
+    {{- end }}
+    ...
+    k0s:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: k0s
+      spec:
+        api:
+          extraArgs:
+            {{- if .Values.auth.configSecret.name }}
+            authentication-config: /var/lib/k0s/auth/config-{{ .Values.auth.configSecret.hash }}.yaml
+            {{- end }}
+     ...
+```
+
+> WARNING:
+> If `spec.clusterAuth` is updated with a different configuration, the hash value will change.
+> This triggers a rolling recreation of the control plane machines.

--- a/docs/admin/clusters/deploy-cluster.md
+++ b/docs/admin/clusters/deploy-cluster.md
@@ -6,7 +6,8 @@ A cluster deployment typically involves:
 
 1. Setting up credentials for the infrastructure provider (for example, AWS, vSphere).
 2. Choosing a template that defines the desired cluster configuration (for example, number of nodes, instance types).
-3. Submitting the configuration for deployment and monitoring the process.
+3. Cluster Authentication setup (optional).
+4. Submitting the configuration for deployment and monitoring the process.
 
 Follow these steps to deploy a standalone Kubernetes cluster tailored to your specific needs:
 
@@ -73,12 +74,16 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     kubectl describe clustertemplate aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}} -n kcm-system
     ```
 
-3. Create a ClusterDeployment YAML Configuration
+3. [Optional] Create `ClusterAuthentication` object to configure authentication for the kubernetes cluster.
+   For details about the IAM configuration, see [Cluster Identity and Authorization Management](cluster-iam-setup.md).
+
+5. Create a ClusterDeployment YAML Configuration
 
     The `ClusterDeployment` object is the main configuration file that defines your cluster's specifications. It includes:
 
     * The template to use
     * The credentials for the infrastructure provider
+    * The name of the ClusterAuthentication object with cluster authentication configuration (optional)
     * Optional customizations such as instance types, regions, and networking
 
     Create a `ClusterDeployment` configuration in a YAML file, following this structure:
@@ -92,6 +97,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     spec:
       template: <template-name>
       credential: <infrastructure-provider-credential-name>
+      clusterAuth: <cluster-authentication-name>
       dryRun: <"true" or "false" (default: "false")>
       cleanupOnDeletion: <"true" or "false" (default: "false")>
       config:
@@ -109,6 +115,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     spec:
       template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
       credential: aws-credential
+      clusterAuth: auth-config-dex
       dryRun: false
       config:
         clusterLabels: {}
@@ -121,7 +128,11 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
           rootVolumeSize: 32
     ```
 
-    Note that the `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+    > NOTE
+    > * The `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+    > * The `.spec.clusterAuth` value should match the `.metadata.name` value of the `ClusterAuthentication` object.
+    > For more information about authentication configuration in {{{ docsVersionInfo.k0rdentName }}} follow
+    > [Cluster Identity and Authorization Management](cluster-iam-setup.md).
 
     > TIP:
     > If automatic cleanup of potentially orphaned *LoadBalancer Services* and *Storage devices* during deletion of
@@ -129,7 +140,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     > This is a best-effort cleanup: if there is no possibility to acquire a managed cluster's kubeconfig,
     > the cleanup will **not** happen.
 
-4. Apply the Configuration
+6. Apply the Configuration
 
     Once the `ClusterDeployment` configuration is ready, apply it to the {{{ docsVersionInfo.k0rdentName }}} management cluster:
 
@@ -139,7 +150,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
 
     This step submits your deployment request to {{{ docsVersionInfo.k0rdentName }}}. If you've set `dryRun` to `true` you can observe what would happen. Otherwise, {{{ docsVersionInfo.k0rdentName }}} will go ahead and begin provisioning the necessary infrastructure.
 
-5. Verify Deployment Status
+7. Verify Deployment Status
 
     After submitting the configuration, verify that the `ClusterDeployment` object has been created successfully:
 
@@ -149,7 +160,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
 
     The output shows the current status and any errors.
 
-6. Monitor Provisioning
+8. Monitor Provisioning
 
     {{{ docsVersionInfo.k0rdentName }}} will now start provisioning resources (for example, VMs and networks) and setting up the cluster. To monitor this process, run:
 
@@ -164,7 +175,7 @@ Follow these steps to deploy a standalone Kubernetes cluster tailored to your sp
     clusterctl describe cluster <cluster-name> -n <namespace> --show-conditions all
     ```
 
-7. Retrieve the Kubernetes Configuration
+9. Retrieve the Kubernetes Configuration
 
     When provisioning is complete, retrieve the kubeconfig file for the new cluster. This file enables you to interact with the cluster using `kubectl`:
 

--- a/docs/admin/clusters/index.md
+++ b/docs/admin/clusters/index.md
@@ -9,3 +9,4 @@ infrastructure choices.  You can also "adopt" Kubernetes clusters created outsid
 - [Updating standalone clusters](update-cluster.md)
 - [Adopting clusters](admin-adopting-clusters.md)
 - [IP Address Management (IPAM)](admin-adopting-clusters.md)
+- [Identity And Authorization Management](cluster-iam-setup.md)

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -114,16 +114,19 @@ The main difference is that {{{ docsVersionInfo.k0rdentName }}}'s way of represe
 The {{{ docsVersionInfo.k0rdentName }}} initialization process involves tools such as Helm and FluxCD.
 
 1. [`helm install kcm`](installation/install-k0rdent.md) brings up the bootstrap components (yellow in the above diagram).
-1. `kcm-controller-manager` sets up webhooks to validate its `CustomResource` objects, then cert-manager handles the webhooks’ certificates.
-1. `kcm-controller-manager` generates a `Release` object corresponding to the KCM helm chart version.
-1. `kcm-controller-manager` (or rather the [release-controller](https://github.com/k0rdent/kcm/blob/main/internal/controller/release_controller.go) inside it) generates template objects (`ProviderTemplate`/`ClusterTemplate`/`ServiceTemplate`) corresponding to a `Release` to be further processed.
-1. `kcm-controller-manager` generates a `HelmRelease` object for every standard template. Note that this includes the KCM helm chart itself.
-1. [Flux](https://github.com/fluxcd/flux2) (source-controller and helm-controller pods) reconciles the *HelmRelease* objects. In other words, it installs all the helm charts referred to in the templates.
+2. `kcm-controller-manager` sets up webhooks to validate its `CustomResource` objects, then cert-manager handles the webhooks’ certificates.
+3. `kcm-controller-manager` generates a `Release` object corresponding to the KCM helm chart version.
+4. `kcm-controller-manager` (or rather the [release-controller](https://github.com/k0rdent/kcm/blob/main/internal/controller/release_controller.go) inside it) generates template objects (`ProviderTemplate`/`ClusterTemplate`/`ServiceTemplate`) corresponding to a `Release` to be further processed.
+5. `kcm-controller-manager` generates a `HelmRelease` object for every standard template. Note that this includes the KCM helm chart itself.
+6. [Flux](https://github.com/fluxcd/flux2) (source-controller and helm-controller pods) reconciles the *HelmRelease* objects. In other words, it installs all the helm charts referred to in the templates.
 **After this point, the deployment is completely controlled by Flux.**
-1. `kcm-controller-manager` creates a `Management` object that refers to the above `Release` and the `ProviderTemplate` objects.
+7. `kcm-controller-manager` creates a `Management` object that refers to the above `Release` and the `ProviderTemplate` objects.
 The `Management` object represents the {{{ docsVersionInfo.k0rdentName }}} management cluster as a whole.
 The management cluster Day-2 operations (such as [upgrade](upgrade/index.md)) are  executed by manipulating the `Release` and `Management` objects.
-1. `kcm-controller-manager` generates an empty `AccessManagement` object. `AccessManagement` defines [access rules](../reference/template/index.md#template-life-cycle-management) for `ClusterTemplate`/`ServiceTemplate` propagation across user namespaces. Further, the `AccessManagement` might be edited and used along with admin-created `ClusterTemplateChain` and `ServiceTemplateChain` objects.
+8. `kcm-controller-manager` generates an empty `AccessManagement` object. `AccessManagement` defines
+[access rules](access/accessmanagement.md) for `ClusterTemplate`, `ServiceTemplate`, `Credential` and
+`ClusterAuthentication` propagation across user namespaces. Further, the `AccessManagement` might be edited and used
+along with admin-created `ClusterTemplateChain`, `ServiceTemplateChain`, `Credential` and `ClusterAuthentication` objects.
 
 This Administration Guide provides information on:
 

--- a/docs/user/user-create-cluster.md
+++ b/docs/user/user-create-cluster.md
@@ -89,7 +89,10 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     kubectl describe clustertemplate aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}} -n kcm-system
     ```
 
-3. Create a ClusterDeployment YAML Configuration
+3. [Optional] Create `ClusterAuthentication` object to configure authentication for the kubernetes cluster.
+   For details about the IAM configuration, see [Cluster Identity and Authorization Management](../admin/clusters/cluster-iam-setup.md).
+
+4. Create a ClusterDeployment YAML Configuration
 
     Once you have the `Credential` and the `ClusterTemplate` you can create the `ClusterDeployment` object configuration.
     It includes:
@@ -109,6 +112,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     spec:
       template: <template-name>
       credential: <infrastructure-provider-credential-name>
+      clusterAuth: <cluster-authentication-name>
       dryRun: <"true" or "false" (default: "false")>
       cleanupOnDeletion: <"true" or "false" (default: "false")>
       config:
@@ -126,6 +130,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     spec:
       template: aws-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.awsStandaloneCpCluster }}}
       credential: aws-credential
+      clusterAuth: auth-config-dex
       config:
         clusterLabels: {}
         region: us-west-2
@@ -135,7 +140,11 @@ Follow these steps to deploy a standalone Kubernetes cluster:
           instanceType: t3.small
     ```
 
-    Note that the `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+    > NOTE
+    > * The `.spec.credential` value should match the `.metadata.name` value of a created `Credential` object.
+    > * The `.spec.clusterAuth` value should match the `.metadata.name` value of the `ClusterAuthentication` object.
+    > For more information about authentication configuration in {{{ docsVersionInfo.k0rdentName }}} follow
+    > [Cluster Identity and Authorization Management](../admin/clusters/cluster-iam-setup.md).
 
     > TIP:
     > If automatic cleanup of potentially orphaned *LoadBalancer Services* and *Storage devices* during deletion of
@@ -143,7 +152,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     > This is a best-effort cleanup: if there is no possibility to acquire a managed cluster's kubeconfig,
     > the cleanup will **not** happen.
 
-4. Apply the Configuration
+5. Apply the Configuration
 
     Once the `ClusterDeployment` configuration is ready, apply it to the {{{ docsVersionInfo.k0rdentName }}} management cluster:
 
@@ -153,7 +162,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
 
     This step submits your deployment request to {{{ docsVersionInfo.k0rdentName }}}.
 
-5. Verify Deployment Status
+6. Verify Deployment Status
 
     After submitting the configuration, verify that the `ClusterDeployment` object has been created successfully:
 
@@ -163,7 +172,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
 
     The output shows the current status and any errors.
 
-6. Monitor Provisioning
+7. Monitor Provisioning
 
     {{{ docsVersionInfo.k0rdentName }}} will now start provisioning resources (for example, VMs or networks) and setting up the cluster. To monitor this process, run:
 
@@ -171,7 +180,7 @@ Follow these steps to deploy a standalone Kubernetes cluster:
     kubectl -n <namespace> get cluster <cluster-name> -o=yaml
     ```
 
-7. Retrieve the Kubernetes Configuration
+8. Retrieve the Kubernetes Configuration
 
     When provisioning is complete, you can retrieve the kubeconfig file for the new cluster so you can interact with the cluster using `kubectl`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
       - Deploying standalone clusters: admin/clusters/deploy-cluster.md
       - Updating standalone clusters: admin/clusters/update-cluster.md
       - Adopting clusters: admin/clusters/admin-adopting-clusters.md
+      - Identity and Authorization Management: admin/clusters/cluster-iam-setup.md
       - IP Address Management (IPAM): admin/clusters/cluster-ipam.md
       - Migrate ClusterDeployment: admin/clusters/migration.md
     - Working with regional clusters:
@@ -199,6 +200,7 @@ nav:
         - Overview: admin/access/rbac/index.md
         - What Roles Do: admin/access/rbac/what-roles-do.md
         - Role Definitions: admin/access/rbac/roles-summary.md
+        - Roles Management: admin/access/rbac/roles-management.md
         - Limiting Access: admin/access/rbac/limiting-access.md
     - Backup and Restore:
       - Overview: admin/backup/index.md


### PR DESCRIPTION
This PR adds documentation and instructions about using the new ClusterAuthentication custom resource and RBAC Manager. Additionally, included a separate section about the `AccessManagement` since now it supports distributing `ClusterAuthentication` objects as well.

Applies starting from:

* OSS v1.6.0
* Enterprise v1.2.0

Related epic https://github.com/k0rdent/kcm/issues/2105

Closes https://github.com/k0rdent/kcm/issues/2103