### PR TITLE
chore: remove `authURL` from openstack instructions

### DIFF
--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -232,7 +232,6 @@
         externalNetwork:
           filter:
             name: "public"
-        authURL: ${OS_AUTH_URL}
         identityRef:
           name: "openstack-cloud-config"
           cloudName: "openstack"
@@ -245,7 +244,7 @@
     > For older template versions, this parameter is required and must match the name of the `Secret` containing the
     > `clouds.yaml` configuration.
 
-    You can adjust `flavor`, `image name`, `region name`, and `authURL` to match your OpenStack environment. For more information about the configuration options, see the [OpenStack Template Parameters Reference](../../../reference/template/template-openstack.md).
+    You can adjust `flavor`, `image name` and `region name` to match your OpenStack environment. For more information about the configuration options, see the [OpenStack Template Parameters Reference](../../../reference/template/template-openstack.md).
 
     Apply the YAML to your management cluster:
 

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -8,7 +8,6 @@ To deploy an OpenStack cluster, the following are the primary parameters in the 
 |-----------------------------------|---------------------------------------|-------------------------------------------------------------|
 | `.spec.credential`                | `openstack-cluster-identity-cred`     | Reference to the `Credential` object.                       |
 | `.spec.template`                  | `openstack-standalone-cp-{{{ extra.docsVersionInfo.providerVersions.dashVersions.openstackStandaloneCpCluster }}}` | Reference to the `ClusterTemplate`. |
-| `.spec.config.authURL`            | `https://keystone.yourorg.net/`       | Keystone authentication endpoint for OpenStack.             |
 | `.spec.config.controlPlaneNumber` | `3`                                   | Number of control plane nodes.                              |
 | `.spec.config.workersNumber`      | `2`                                   | Number of worker nodes.                                     |
 | `.spec.config.clusterLabels`      | `k0rdent: demo`                       | Labels to apply to the cluster. Used by MultiClusterService.|
@@ -182,7 +181,6 @@ spec:
     externalNetwork:
       filter:
         name: "public"
-    authURL: https://my-keystone-openstack-url.com
     identityRef:
       name: openstack-cloud-config
       cloudName: openstack


### PR DESCRIPTION
This parameter is unused.

Applies to all k0rdent OSS and Enterprise versions.