### PR TITLE
Fixed bad link in architecture in release-v1.0.0

### DIFF
--- a/docs/concepts/k0rdent-architecture.md
+++ b/docs/concepts/k0rdent-architecture.md
@@ -82,7 +82,7 @@ To solve this problem, {{{ docsVersionInfo.k0rdentName }}} lets you create a `Cr
 3. Developers reference the `Credential` object, which gives the cluster the ability to access these credentials (little “c”) without having to expose them to developers directly.
 
 > NOTE:
-> To be sure credentials are not visible to developers, make sure to [limit access](../admin/access/rbac/roles-summary.md#limit-credential-access) to the `kcm-system` namespace.
+> To be sure credentials are not visible to developers, make sure to [limit access](../admin/access/rbac/limiting-access.md) to the `kcm-system` namespace.
 
 ## TL;DR - Conclusion
 


### PR DESCRIPTION
(cherry picked from commit e573dba21f79e75758fc13fde13edc42704e05f9)