### PR TITLE
fix: remove self-management cluster selector labels

### DIFF
--- a/docs/admin/ksm/ksm-self-management.md
+++ b/docs/admin/ksm/ksm-self-management.md
@@ -20,7 +20,7 @@ spec:
 
 This will create a ServiceSet which will also have `.spec.serviceSpec.provider.selfManagement=true`, which in-turn will indicate to the KSM [StateManagementProvider](ksm-providers.md) that this MCS is supposed to match the management cluster itself. 
 
-The default StateManagementProvider is Sveltos, so there is a SveltosCluster object named mgmt in the mgmt namespace where k0rdent has been installed. This object represents the management cluster itself. To view this object run:
+The default StateManagementProvider is Sveltos, so there is a SveltosCluster object named mgmt in the mgmt namespace of the cluster where k0rdent has been installed. This object represents the management cluster itself. To view this object run:
 
 ```sh
 kubectl -n mgmt get sveltoscluster mgmt --show-labels

--- a/docs/admin/ksm/ksm-self-management.md
+++ b/docs/admin/ksm/ksm-self-management.md
@@ -20,7 +20,7 @@ spec:
 
 This will create a ServiceSet which will also have `.spec.serviceSpec.provider.selfManagement=true`, which in-turn will indicate to the KSM [StateManagementProvider](ksm-providers.md) that this MCS is supposed to match the management cluster itself. 
 
-The default StateManagementProvider is Sveltos, so there is a SveltosCluster object named mgmt in the mgmt namespace of the cluster where k0rdent has been installed. This object represents the management cluster itself. To view this object run:
+The default StateManagementProvider is Sveltos, so there is a object named mgmt in the mgmt namespace of the cluster where k0rdent has been installed. This object represents the management cluster itself, and is different from the default k0rdent namespace such as `kcm-system`. To view this object run:
 
 ```sh
 kubectl -n mgmt get sveltoscluster mgmt --show-labels

--- a/docs/admin/ksm/ksm-self-management.md
+++ b/docs/admin/ksm/ksm-self-management.md
@@ -1,6 +1,26 @@
 # Deploy beach-head services on Management Cluster itself
 
-There is a SveltosCluster object named mgmt in the mgmt namespace where k0rdent has been installed. This object represents the management cluster itself. The following command can be used to get this object along with labels:
+To deploy beach-head services on the management cluster, a MultiClusterService object can be created with `.spec.serviceSpec.provider.selfManagement=true` as shown below: 
+
+```yaml
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: MultiClusterService
+metadata:
+  name: mgmt-mcs
+spec:
+  serviceSpec:
+    provider:
+      name: ksm-projectsveltos
+      selfManagement: true
+    services:
+      - template: ingress-nginx-4-11-3
+        name: ingress-nginx
+        namespace: ingress-nginx
+```
+
+This will create a ServiceSet which will also have `.spec.serviceSpec.provider.selfManagement=true`, which in-turn will indicate to the KSM [StateManagementProvider](ksm-providers.md) that this MCS is supposed to match the management cluster itself. 
+
+The default StateManagementProvider is Sveltos, so there is a SveltosCluster object named mgmt in the mgmt namespace where k0rdent has been installed. This object represents the management cluster itself. To view this object run:
 
 ```sh
 kubectl -n mgmt get sveltoscluster mgmt --show-labels
@@ -11,28 +31,6 @@ The output should be similar to this:
 ```sh
 NAME   READY   VERSION   LABELS
 mgmt   true    v1.32.2   k0rdent.mirantis.com/management-cluster=true,projectsveltos.io/k8s-version=v1.32.2,sveltos-agent=present
-```
-
-To deploy beach-head services on the management cluster, a MultiClusterService object can be created that matches the mgmt SveltosCluster using the k0rdent.mirantis.com/management-cluster=true and sveltos-agent=present labels as shown in the following YAML:
-
-```yaml
-apiVersion: k0rdent.mirantis.com/v1beta1
-kind: MultiClusterService
-metadata:
-  name: mgmt-mcs
-spec:
-  clusterSelector:
-    matchLabels:
-      k0rdent.mirantis.com/management-cluster: "true"
-      sveltos-agent: present
-  serviceSpec:
-    provider:
-      name: ksm-projectsveltos
-      selfManagement: true
-    services:
-      - template: ingress-nginx-4-11-3
-        name: ingress-nginx
-        namespace: ingress-nginx
 ```
 
 Any number of ServiceTemplates (ingress-nginx-4-11-3 in this example) can be added to the MultiClusterService's `.spec.serviceSpec.services` field. See [Using and Creating ServiceTemplates](./ksm-service-templates.md) for how to create ServiceTemplates.


### PR DESCRIPTION
We no longer need to specify selector labels in the MCS object to self-manage the management/mothership cluster. Kindly see https://github.com/k0rdent/kcm/pull/2315 for more detail.

Fixes: https://github.com/k0rdent/kcm/issues/2223