### PR TITLE
docs: remove telemetry inaccurate item

### DIFF
--- a/docs/appendix/telemetry/data_collected.md
+++ b/docs/appendix/telemetry/data_collected.md
@@ -16,7 +16,6 @@ The KCM controller periodically scrapes each managed cluster and records:
 * **Identification labels**: cluster namespaced name,
   [ClusterDeployment](../../reference/crds/index.md#clusterdeployment) UID,
   and k0s cluster ID.
-* **IPAM allocation**: the number of [ClusterIPAM](../../reference/crds/index.md#clusteripam) bound in a cluster and the overall number of [ClusterIPAM](../../reference/crds/index.md#clusteripam) objects in a cluster
 
 The exact metrics and their representation vary from the mode.
 


### PR DESCRIPTION
Changes:
* `docs/appendix/telemetry/data_collected.md`: removes the incorrect statement that the telemetry collector collects IPAM-related data

Reason: the telemetry collector has never collected any IPAM-related data, and this might have confused the docs' readers.