### PR TITLE
KOF 1.7.0: M2R: kind: PKI_PATH, invalid keys: address, istio

### DIFF
--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -155,7 +155,6 @@ To apply this option:
                 - basicauth/traces
               telemetry:
                 metrics:
-                  address: \${env:OTEL_K8S_NODE_IP}:8888
                   readers:
                     - pull:
                         exporter:
@@ -262,7 +261,17 @@ It assumes that:
 
 To apply this option:
 
-1. Create the `collectors-values.yaml` file:
+1. Run in the management cluster:
+    ```bash
+    VMUSER_CREDS_NAME=$(
+      kubectl get secret -n kof \
+      | grep vmuser-creds-admin \
+      | cut -d ' ' -f 1
+    )
+    echo $VMUSER_CREDS_NAME
+    ```
+
+2. Create the `collectors-values.yaml` file:
     ```bash
     cat >collectors-values.yaml <<EOF
     kcm:
@@ -283,7 +292,21 @@ To apply this option:
               - file_storage/filelogsyslogreceiver
               - file_storage/filelogk8sauditreceiver
               - file_storage/journaldreceiver
+              - basicauth/metrics
+              - basicauth/logs
+              - basicauth/traces
       defaultCRConfig:
+        env:
+          - name: KOF_VM_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: $VMUSER_CREDS_NAME
+          - name: KOF_VM_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: $VMUSER_CREDS_NAME
         config:
           processors:
             resource/k8sclustername:
@@ -294,26 +317,67 @@ To apply this option:
                 - action: insert
                   key: k8s.cluster.namespace
                   value: kcm-system
+          extensions:
+            basicauth/logs:
+              client_auth:
+                username: \${env:KOF_VM_USER}
+                password: \${env:KOF_VM_PASSWORD}
+            basicauth/metrics:
+              client_auth:
+                username: \${env:KOF_VM_USER}
+                password: \${env:KOF_VM_PASSWORD}
+            basicauth/traces:
+              client_auth:
+                username: \${env:KOF_VM_USER}
+                password: \${env:KOF_VM_PASSWORD}
+          service:
+            extensions:
+            - basicauth/logs
+            - basicauth/metrics
+            - basicauth/traces
           exporters:
             prometheusremotewrite:
-              endpoint: http://$REGIONAL_CLUSTER_NAME-vminsert:8480/insert/0/prometheus/api/v1/write
+              endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vm/insert/0/prometheus/api/v1/write
+              auth:
+                authenticator: basicauth/metrics
               external_labels:
                 cluster: mothership
                 clusterNamespace: kcm-system
             otlphttp/logs:
-              logs_endpoint: http://$REGIONAL_CLUSTER_NAME-logs-insert:9481/insert/opentelemetry/v1/logs
+              logs_endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vli/insert/opentelemetry/v1/logs
+              auth:
+                authenticator: basicauth/logs
             otlphttp/traces:
-              traces_endpoint: http://$REGIONAL_CLUSTER_NAME-traces-insert:10481/insert/opentelemetry/v1/traces
+              traces_endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vti/insert/opentelemetry/v1/traces
+              auth:
+                authenticator: basicauth/traces
     opencost:
       opencost:
         prometheus:
-          existingSecretName: ""
+          existingSecretName: $VMUSER_CREDS_NAME
           external:
-            url: http://$REGIONAL_CLUSTER_NAME-vmselect:8481/select/0/prometheus
+            url: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vm/select/0/prometheus
     EOF
     ```
 
-2. Install the `kof-collectors` chart to the management cluster:
+    If you're using `kind` for Management cluster, insert this:
+
+    ```
+    ...
+      defaultCRConfig:
+        env:
+          - name: PKI_PATH
+            value: etc/kubernetes
+          - name: KOF_VM_USER
+    ...
+    ```
+
+    > NOTE:
+    > If you create this file directly, make sure to replace `\$` with `$`,
+    > `$VMUSER_CREDS_NAME` with the value from step 1,
+    > and `$REGIONAL_CLUSTER_NAME` with the value from [Installing KOF - Regional Cluster](kof-install.md/#regional-cluster).
+
+3. Install the `kof-collectors` chart to the management cluster:
     ```bash
     helm upgrade -i --reset-values --wait -n kof kof-collectors \
       -f collectors-values.yaml \

--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -227,6 +227,18 @@ To apply this option:
     EOF
     ```
 
+    If you're using `kind` for Management cluster, insert this:
+
+    ```
+    ...
+      defaultCRConfig:
+        env:
+          - name: PKI_PATH
+            value: etc/kubernetes
+          - name: KOF_VM_USER
+    ...
+    ```
+
     > NOTE:
     > If you create this file directly, make sure to replace `\$` with `$`,
     > `$VMUSER_CREDS_NAME` with the value from step 1,


### PR DESCRIPTION
* Related to https://github.com/k0rdent/kof/pull/713
* Management cluster via `kind` had this error:
  ```
  kubectl logs -n kof kof-collectors-controller-k0s-daemon-collector-5fgfj

  2026-01-29T22:27:22.373Z	warn	envprovider@v1.49.0/provider.go:61
  Configuration references unset environment variable	{"name": "PKI_PATH"}
  Error: invalid configuration: receivers::prometheus::config:
  error checking client cert file "/hostfs//pki/apiserver-etcd-client.crt":
  stat /hostfs//pki/apiserver-etcd-client.crt: no such file or directory
  ```
* This change in current PR fixed the issue:

<img width="948" height="282" alt="Screenshot 2026-01-30 at 00 19 18" src="https://github.com/user-attachments/assets/907e2699-fce6-44f2-8d03-d65a60a58340" />

* Also added the fix for this issue:
  ```
  kubectl logs -n kof kof-collectors-daemon-collector-tvxnc

  Error: failed to get config: cannot unmarshal the configuration:
  decoding failed due to the following error(s):
  'service.telemetry.metrics' decoding failed due to the following error(s):
  '' has invalid keys: address
  ```
  which was to delete the outdated `address: \${env:OTEL_K8S_NODE_IP}:8888` line.
* Also updated the "From Management to Regional with Istio" case.

