### PR TITLE
Adjust GKE service account permissions

### DIFF
--- a/docs/admin/installation/prepare-mgmt-cluster/gcp.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/gcp.md
@@ -44,8 +44,14 @@ Standalone clusters can be deployed on GCP instances. Follow these steps to make
     > Skip this step if the Service Account already configured
 
     Follow the [GCP Service Account creation guide](https://cloud.google.com/iam/docs/service-accounts-create#creating)
-    and create a new service account with `Editor` permissions.
-    If you have plans to deploy `GKE`, the Service Account will also need the `iam.serviceAccountTokenCreator` role.
+    and create a new service account with `Editor` permissions. 
+    
+    If you have plans to deploy `GKE`, the Service Account will also need all the permissions described in the
+    [API permissions documentation](https://docs.cloud.google.com/kubernetes-engine/docs/reference/api-permissions).
+    For example, assigning the `Owner` role satisfies these requirements. In addition, the Service Account must also
+    have the `iam.serviceAccountTokenCreator` role.
+    Ensure the Service Account has all necessary permissions to manage the GKE and Kubernetes resources required for
+    your cluster deployment.
 
 6. Generate a JSON Key for the GCP Service Account
 

--- a/docs/quickstarts/quickstart-2-gcp.md
+++ b/docs/quickstarts/quickstart-2-gcp.md
@@ -37,10 +37,16 @@ gcloud config set project PROJECT_ID
 
 > NOTE:
 > Skip this step if the Service Account already configured
+
 Follow the [GCP Service Account creation guide](https://cloud.google.com/iam/docs/service-accounts-create#creating)
 and create a new service account with `Editor` permissions.
 
-If you have plans to deploy `GKE`, the Service Account will also need the `iam.serviceAccountTokenCreator` role.
+If you have plans to deploy `GKE`, the Service Account will also need all the permissions described in the
+[API permissions documentation](https://docs.cloud.google.com/kubernetes-engine/docs/reference/api-permissions).
+For example, assigning the `Owner` role satisfies these requirements. In addition, the Service Account must also
+have the `iam.serviceAccountTokenCreator` role.
+Ensure the Service Account has all necessary permissions to manage the GKE and Kubernetes resources required for
+your cluster deployment.
 
 ## Generate JSON Key for the GCP Service Account
 


### PR DESCRIPTION
The old roles are not enough for the sveltos-agent and services to be installed properly on GKE clusters.

Applicable for all versions (both OSS and enterprise).

Related bug: https://github.com/k0rdent/kcm/issues/2092