### PR TITLE
KOF 1.8.0 Multi-tenancy Usage Examples, Expose Dex, M2M fix

### DIFF
--- a/docs/admin/kof/kof-grafana.md
+++ b/docs/admin/kof/kof-grafana.md
@@ -172,10 +172,10 @@ All dashboards are managed as code to keep environments consistent. To add or ch
 Port forwarding, as described above, is a quick solution.
 
 Single Single-On provides better experience. If you want to enable it,
-please apply this advanced guide: [SSO for Grafana](https://github.com/k0rdent/kof/blob/main/docs/dex-sso.md).
+please apply this advanced guide: [Dex SSO for Grafana](https://github.com/k0rdent/kof/blob/main/docs/dex-sso.md).
 
-See also [Multi-tenancy in KOF: Single Sign-On](kof-multi-tenancy.md#single-sign-on)
-and the next sections there for additional examples.
+See also [Multi-tenancy in KOF: Usage Examples](kof-multi-tenancy.md#usage-examples)
+for additional Dex SSO examples.
 
 ## Uninstall Grafana
 

--- a/docs/admin/kof/kof-multi-tenancy.md
+++ b/docs/admin/kof/kof-multi-tenancy.md
@@ -42,13 +42,16 @@ k0rdent.mirantis.com/kof-tenant-id: <TENANT_ID>
 
 Dependent resources (secrets, VMUser object) will be updated or created automatically. See [storage credentials](https://github.com/k0rdent/kof/blob/main/docs/storage-creds.md) for details.
 
-The next examples assume:
+## Usage Examples
 
-* [Dex SSO](kof-grafana.md#single-sign-on) is deployed to `dex.example.com`
-* Optional [Grafana in KOF](kof-grafana.md) integration is enabled.
-    Some other dashboarding tools may be connected in the same way.
-* Google is used as an OIDC provider.
-    Any other [OIDC provider](https://dexidp.io/docs/connectors/oidc/) can be used.
+The next examples show how to test multi-tenancy using
+local management cluster with [Grafana in KOF](kof-grafana.md)
+integrated with local [Dex SSO](kof-grafana.md#single-sign-on)
+exposed as `dex.example.com:32000` and configured to use Google OIDC provider.
+
+Other dashboarding tools, [OIDC providers](https://dexidp.io/docs/connectors/oidc/),
+and remote management cluster can be used instead.
+Please adapt these reference examples to your own case.
 
 ## Single Sign-On
 
@@ -96,94 +99,154 @@ grant full access to all tenants and features.
 
 "Sign in with Dex" followed by "Log in with Email" grants access to all tenants and limited features.
 
-To enable this option, get admin email and password hash,
-and apply the `kof-values.yaml` patch to the [Management Cluster](kof-install.md/#management-cluster)
-using this example:
+To enable this option and Dex in general with [Usage Examples](#usage-examples) assumptions:
 
-```bash
-ADMIN_EMAIL=$(git config user.email)
-ADMIN_PASSWORD_HASH=$(htpasswd -BnC 10 admin | cut -d: -f2)
+1. ??? note "Get admin email and password hash:"
 
-cat <<EOF
-kof-mothership:
-  values:
-    kcm:
-      kof:
-        acl:
-          enabled: true
-          replicaCount: 1
-          extraArgs:
-            issuer: https://dex.example.com:32000
-            admin-email: "$ADMIN_EMAIL"
-    dex:
-      enabled: true
-      config:
-        connectors: []
-        issuer: https://dex.example.com:32000
-        enablePasswordDB: true
-        staticPasswords:
-          - email: "$ADMIN_EMAIL"
-            hash: "$ADMIN_PASSWORD_HASH"
-            username: "admin"
-            userID: "1"
-        oauth2:
-          passwordConnector: local
-        staticClients:
-          - id: grafana-id
-            redirectURIs:
-              - "http://localhost:3000/login/generic_oauth"
-            name: Grafana
-            secret: grafana-secret
-EOF
-```
+        ```bash
+        ADMIN_EMAIL=$(git config user.email)
+        ADMIN_PASSWORD_HASH=$(htpasswd -BnC 10 admin | cut -d: -f2)
+        ```
+
+2. ??? note "Create the `kof-values.yaml` patch:"
+
+        ```bash
+        cat <<EOF
+        kof-mothership:
+          values:
+            kcm:
+              kof:
+                acl:
+                  enabled: true
+                  developmentMode: true  # For local test only: self-signed Dex TLS
+                  replicaCount: 1
+                  extraArgs:
+                    issuer: https://dex.example.com:32000
+                    admin-email: "$ADMIN_EMAIL"
+            dex:
+              enabled: true
+              config:
+                issuer: https://dex.example.com:32000
+                enablePasswordDB: true
+                staticPasswords:
+                  - email: "$ADMIN_EMAIL"
+                    hash: "$ADMIN_PASSWORD_HASH"
+                    username: "admin"
+                    userID: "1"
+                oauth2:
+                  passwordConnector: local
+                staticClients:
+                  - id: grafana-id
+                    redirectURIs:
+                      - "http://localhost:3000/login/generic_oauth"
+                    name: Grafana
+                    secret: grafana-secret
+                connectors: []
+        EOF
+        ```
+
+3. Patch `kof-values.yaml` and apply it to the [Management Cluster](kof-install.md/#management-cluster).
+
+4. ??? note "Expose Dex at local management cluster as `https://dex.example.com:32000`"
+
+        ```bash
+        grep -qxF "127.0.0.1 dex.example.com" /etc/hosts \
+          || echo "127.0.0.1 dex.example.com" | sudo tee -a /etc/hosts
+
+        node_internal_ip=$(kubectl get node k0rdent-control-plane \
+          -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'
+        )
+
+        kubectl get ns kof || kubectl create ns kof
+        git clone git@github.com:k0rdent/kof.git
+        cd ./kof
+        bash scripts/generate-dex-secret.bash
+        bash scripts/patch-coredns.bash kubectl dex.example.com $node_internal_ip
+
+        kubectl rollout restart deploy/coredns -n kube-system
+        kubectl rollout status deploy/coredns -n kube-system --timeout=1m
+
+        kubectl rollout restart deploy/kof-mothership-dex -n kof
+        kubectl rollout status deploy/kof-mothership-dex -n kof --timeout=1m
+
+        kubectl port-forward svc/kof-mothership-dex 32000:5554 -n kof
+        ```
+
+5. Apply the [Install and enable Grafana](kof-grafana.md#install-and-enable-grafana).
+
+6. ??? note "Integrate Grafana with Dex:"
+
+        ```bash
+        cat >grafana-dex.yaml <<EOF
+        spec:
+          config:
+            auth.generic_oauth:
+              enabled: "true"
+              name: Dex
+              scopes: "openid email profile groups offline_access"
+              auth_url: https://dex.example.com:32000/auth
+              token_url: https://dex.example.com:32000/token
+              api_url: https://dex.example.com:32000/userinfo
+              client_id: grafana-id
+              client_secret: grafana-secret
+              tls_skip_verify_insecure: "true"
+        EOF
+
+        kubectl patch -n kof grafana grafana-vm --type merge \
+          --patch-file=grafana-dex.yaml
+        ```
 
 ### SSO User
 
 "Sign in with Dex" followed by "Log in with Google" grants access to a single tenant and limited features.
 
-To enable this option, get your existing `<GOOGLE_CLIENT_ID>` and `<GOOGLE_CLIENT_SECRET>`
-or create the new ones:
+To enable this option:
 
-* Open the [Google Cloud Console](https://console.cloud.google.com/).
-* Create a project, e.g. `dex`
-* Configure OAuth screen:
-    * Audience: Internal (initially, while you're testing it)
-* Create OAuth client:
-    * App type: Web app
-    * Authorized JavaScript origins: `https://dex.example.com:32000`
-    * Authorized redirect URIs: `https://dex.example.com:32000/callback`
-    * Create, download JSON with creds, copy `client_id` and `client_secret`.
+1. ??? note "Create Google OIDC credentials for `https://dex.example.com:32000`:"
 
-Now apply the [SSO Admin](#sso-admin) patch with the next part added,
-replacing `<GOOGLE_CLIENT_ID>` and `<GOOGLE_CLIENT_SECRET>`:
+        * Open the [Google Cloud Console](https://console.cloud.google.com/).
+        * Create a project, e.g. `dex`
+        * Configure OAuth screen:
+            * Audience: Internal (initially, while you're testing it)
+        * Create OAuth client:
+            * App type: Web app
+            * Authorized JavaScript origins: `https://dex.example.com:32000`
+            * Authorized redirect URIs: `https://dex.example.com:32000/callback`
+            * Create, download JSON with creds, copy `client_id` and `client_secret`.
 
-```yaml
-kof-mothership:
-  values:
-    dex:
-      config:
-        connectors:
-          - type: oidc
-            id: google
-            name: Google
-            config:
-              issuer: https://accounts.google.com
-              clientID: "<GOOGLE_CLIENT_ID>"
-              clientSecret: "<GOOGLE_CLIENT_SECRET>"
-              redirectURI: https://dex.example.com:32000/callback
-              insecureEnableGroups: true
-              claimModifications:
-                newGroupFromClaims:
-                  - prefix: tenant
-                    delimiter: ":"
-                    clearDelimiter: false
-                    claims:
-                      - hd
-              scopes:
-                - openid
-                - email
-                - profile
-```
+2. Apply the [SSO Admin](#sso-admin) steps
+    with the next part added to `kof-values.yaml`,
+    replacing `<GOOGLE_CLIENT_ID>` and `<GOOGLE_CLIENT_SECRET>`:
+
+    ??? note "Google OIDC connectors:"
+
+        ```yaml
+        kof-mothership:
+          values:
+            dex:
+              config:
+                connectors:
+                  - type: oidc
+                    id: google
+                    name: Google
+                    config:
+                      issuer: https://accounts.google.com
+                      clientID: "<GOOGLE_CLIENT_ID>"
+                      clientSecret: "<GOOGLE_CLIENT_SECRET>"
+                      redirectURI: https://dex.example.com:32000/callback
+                      insecureEnableGroups: true
+                      claimModifications:
+                        newGroupFromClaims:
+                          - prefix: tenant
+                            delimiter: ":"
+                            clearDelimiter: false
+                            claims:
+                              - hd
+                      scopes:
+                        - openid
+                        - email
+                        - profile
+        ```
 
 KOF ACL uses either `tenant` claim or `tenant:...` group in the `groups` claim.
 
@@ -200,3 +263,7 @@ KOF ACL uses either `tenant` claim or `tenant:...` group in the `groups` claim.
     * So the [claimModifications](https://dexidp.io/docs/connectors/oidc/#configuration)
         in the Dex configuration above add a new group like `tenant:example.com` to the `groups` claim.
     * KOF ACL finds the `tenant:...` group in the `groups` claim to identify the tenant.
+
+??? note "If you see the `Missing saved oauth state` error:"
+
+    Just retry "Sign in with Dex" followed by "Log in with Google", it should work.

--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -41,25 +41,10 @@ This option stores KOF data of the management cluster in the same management clu
 
 To apply this option:
 
-1. Modify the `kof-values.yaml` file:
+1. Update the `kof-values.yaml` file:
     ```yaml
     kof-storage:
-      values:
-        enabled: true
-    ```
-
-    If you want to use a non-default storage class, add to the `kof-values.yaml` file:
-    ```yaml
-    kof-storage:
-      values:
-        victoria-logs-cluster:
-          vlstorage:
-            persistentVolume:
-              storageClassName: <EXAMPLE_STORAGE_CLASS>
-    ```
-
-2. Modify the `kof-values.yaml` file:
-    ```yaml
+      enabled: true
     kof-collectors:
       enabled: true
       values:
@@ -83,6 +68,16 @@ To apply this option:
                   external_labels:
                     cluster: mothership
                     clusterNamespace: kcm-system
+    ```
+
+2. If you want to use a non-default storage class, add to the `kof-values.yaml` file:
+    ```yaml
+    kof-storage:
+      values:
+        victoria-logs-cluster:
+          vlstorage:
+            persistentVolume:
+              storageClassName: <EXAMPLE_STORAGE_CLASS>
     ```
 
 3. Update the `kof` chart on the management cluster:


### PR DESCRIPTION
* Adds more "Usage Examples" to "Multi-tenancy in KOF",
* especially the critical for testing "Expose Dex at local management cluster as `https://dex.example.com:32000`".
* Also fixes the "Storing KOF data - From Management to Management" case which had `enabled: true` at wrong level.

<img width="783" height="311" alt="Screenshot 2026-03-03 at 22 43 09" src="https://github.com/user-attachments/assets/a15fca60-64e0-4291-935a-499a5edd7f57" />
<img width="616" height="710" alt="Screenshot 2026-03-03 at 22 44 10" src="https://github.com/user-attachments/assets/88660d8e-ded4-4c8b-aefe-b26b8f90a3b8" />
<img width="438" height="644" alt="Screenshot 2026-03-03 at 22 44 42" src="https://github.com/user-attachments/assets/c2b3e451-eb50-4612-983f-9cde5751dde0" />
