### PR TITLE
docs: fix invalid serviceTemplate example

### DIFF
--- a/docs/user/services/understanding-servicetemplates.md
+++ b/docs/user/services/understanding-servicetemplates.md
@@ -87,13 +87,13 @@ Helm-based `ServiceTemplate` can be created in three ways:
   spec:
     helm:
       chartSource:
-        remoteSourceRef:
+        path: "./charts"
+        remoteSourceSpec:
           git:
             url: https://github.com/bar/foo.git
             reference:
               branch: main
             interval: 10m
-          path: "./charts"
   ```
 
 ### Kustomize-based ServiceTemplate


### PR DESCRIPTION
(cherry picked from commit 23c1abc915be455410ba4cc4e24cff87f4fa8fe5)