### PR TITLE
KOF ingress/LB fix for multiple regional clusters

### DIFF
--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -399,6 +399,9 @@ apply this example for AWS, or use it as a reference:
             clusterAnnotations:
               k0rdent.mirantis.com/kof-regional-domain: $REGIONAL_DOMAIN
               k0rdent.mirantis.com/kof-cert-email: $ADMIN_EMAIL
+              k0rdent.mirantis.com/kof-ingress-nginx-values: |
+                controller:
+                  name: $REGIONAL_CLUSTER_NAME
             region: $REGION
             controlPlaneNumber: 1
             controlPlane:
@@ -434,6 +437,9 @@ apply this example for AWS, or use it as a reference:
             clusterAnnotations:
               k0rdent.mirantis.com/kof-regional-domain: $REGIONAL_DOMAIN
               k0rdent.mirantis.com/kof-cert-email: $ADMIN_EMAIL
+              k0rdent.mirantis.com/kof-ingress-nginx-values: |
+                controller:
+                  name: $REGIONAL_CLUSTER_NAME
             subscriptionID: $AZURE_SUBSCRIPTION_ID
             location: $REGION
             controlPlaneNumber: 1
@@ -470,6 +476,9 @@ apply this example for AWS, or use it as a reference:
             clusterAnnotations:
               k0rdent.mirantis.com/kof-regional-domain: $REGIONAL_DOMAIN
               k0rdent.mirantis.com/kof-cert-email: $ADMIN_EMAIL
+              k0rdent.mirantis.com/kof-ingress-nginx-values: |
+                controller:
+                  name: $REGIONAL_CLUSTER_NAME
             controlPlaneNumber: 1
             controlPlane:
               flavor: $FLAVOR

--- a/docs/admin/kof/kof-verification.md
+++ b/docs/admin/kof/kof-verification.md
@@ -88,7 +88,7 @@ and [Istio](./kof-install.md#istio), you will need to do the following:
 1. Get the `EXTERNAL-IP` of `ingress-nginx`:
     ```bash
     KUBECONFIG=regional-kubeconfig kubectl get svc \
-      -n kof ingress-nginx-controller
+      -n kof ingress-nginx-$REGIONAL_CLUSTER_NAME
     ```
     It should look like `REDACTED.us-east-2.elb.amazonaws.com`
 
@@ -96,7 +96,8 @@ and [Istio](./kof-install.md#istio), you will need to do the following:
     ```bash
     echo vmauth.$REGIONAL_DOMAIN
     ```
-    Only if Grafana is [installed and enabled](kof-grafana.md), do the same for:
+    Only if Grafana is [installed and enabled](kof-grafana.md) in the regional cluster too
+    (not just in the management cluster), do the same for:
     ```bash
     echo grafana.$REGIONAL_DOMAIN
     ```


### PR DESCRIPTION
* The workaround required to avoid collision of LoadBalancer name when multiple KOF regional clusters are deployed to the same cloud account.
* We will need to check if Envoy Gateway needs something similar in https://github.com/k0rdent/docs/pull/744