### PR TITLE
ksm: add note for mcs matching cluterdeployment in other ns

### DIFF
--- a/docs/admin/ksm/ksm-multiclusterservice.md
+++ b/docs/admin/ksm/ksm-multiclusterservice.md
@@ -113,7 +113,7 @@ This MultiClusterService will match any CAPI cluster with the label `app.kuberne
 version 4.11.3 of ingress-nginx service on it.
 
 > NOTE:
-> If the MultiClusterService matches a ClusterDeployment in a namespace other than `kcm-system`, the MCS will expect the ServiceTemplates used in its `.spec.serviceSpec.services` to already be available and ready in that namespace as well as in `kcm-system` namespace.
+> If the `MultiClusterService` matches a `ClusterDeployment` in a namespace other than `kcm-system`, the MCS will expect the `ServiceTemplates` used in its `.spec.serviceSpec.services` to already be available and ready in that namespace as well as in the `kcm-system` namespace.
 
 ### Configuring Custom Values
 

--- a/docs/admin/ksm/ksm-multiclusterservice.md
+++ b/docs/admin/ksm/ksm-multiclusterservice.md
@@ -112,6 +112,9 @@ spec:
 This MultiClusterService will match any CAPI cluster with the label `app.kubernetes.io/managed-by: Helm` and deploy chart
 version 4.11.3 of ingress-nginx service on it.
 
+> NOTE:
+> If the MultiClusterService matches a ClusterDeployment in a namespace other than `kcm-system`, the MCS will expect the ServiceTemplates used in its `.spec.serviceSpec.services` to already be available and ready in that namespace as well as in `kcm-system` namespace.
+
 ### Configuring Custom Values
 
 Refer to "Configuring Custom Values" in [Deploy beach-head Services using Cluster Deployment](../../user/services/beach-head.md#deployment-of-beach-head-services) for more information on using custom values.


### PR DESCRIPTION
Add note that explains what MCS expects when matching a ClusterDeployment in a namespace other than `kcm-system` namespace. Fixes part of https://github.com/k0rdent/kcm/issues/2567.