### PR TITLE
KOF workaround: OpenCost for OpenStack and other unsupported providers

### DIFF
--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -667,6 +667,12 @@ apply this example for AWS, or use it as a reference:
                   secretName: external-dns-openstack-credentials
         ```
 
+{%
+    include-markdown "../../../includes/kof-install-includes.md"
+    start="<!--opencost-openstack-start-->"
+    end="<!--opencost-openstack-end-->"
+%}
+
 11. Verify and apply the Regional `ClusterDeployment`:
 
     ```bash
@@ -843,20 +849,25 @@ apply this example for AWS, or use it as a reference:
 
     To pass any custom [values](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-collectors/values.yaml)
     to the `kof-collectors` chart or its subcharts, such as [opencost](https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/README.md#values),
-    add them to the `child-cluster.yaml` file in the `.spec.config`. Example:
+    add them to the `child-cluster.yaml` file in the `.spec.config.clusterAnnotations`. Example:
 
     ??? note "OpenCost replicas"
 
         ```yaml
-        clusterAnnotations:
-          k0rdent.mirantis.com/kof-collectors-values: |
+        k0rdent.mirantis.com/kof-collectors-values: |
+          opencost:
             opencost:
-              opencost:
-                exporter:
-                  replicas: 2
+              exporter:
+                replicas: 2
         ```
 
         Note: the first `opencost` key is to reference the subchart, and the second `opencost` key is part of its [values](https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/README.md#values).
+
+{%
+    include-markdown "../../../includes/kof-install-includes.md"
+    start="<!--opencost-openstack-start-->"
+    end="<!--opencost-openstack-end-->"
+%}
 
 8. Verify and apply the `ClusterDeployment`:
 

--- a/includes/kof-install-includes.md
+++ b/includes/kof-install-includes.md
@@ -27,6 +27,28 @@
   ```
 <!--install-kof-end-->
 
+<!--opencost-openstack-start-->
+    ??? note "OpenCost for OpenStack and other unsupported providers"
+
+        Workaround for [opencost/opencost issue #2925](https://github.com/opencost/opencost/issues/2925)
+        to avoid `Error getting LoadBalancer cost: strconv.ParseFloat: parsing "": invalid syntax`:
+
+        ```yaml
+        k0rdent.mirantis.com/kof-collectors-values: |
+          opencost:
+            opencost:
+              customPricing:
+                enabled: true
+                costModel:
+                  firstFiveForwardingRulesCost: 0
+                  additionalForwardingRuleCost: 0
+                  LBIngressDataCost: 0
+        ```
+
+        Please also consider configuring cost of [default](https://github.com/opencost/opencost-helm-chart/blob/opencost-2.4.0/charts/opencost/values.yaml#L329-L339)
+        and [advanced](https://github.com/opencost/opencost/blob/v1.118.0/pkg/cloud/models/models.go#L121-L198) resources.
+<!--opencost-openstack-end-->
+
 <!--grafana-intro-start-->
 > NOTE:
 > Grafana installation and automatic configuration are now disabled in KOF by default.

--- a/includes/kof-upgrade-includes.md
+++ b/includes/kof-upgrade-includes.md
@@ -14,7 +14,7 @@ KOF v1.9.0 introduces a [Gateway API](http://gateway-api.sigs.k8s.io/) support.
 
 2. **Migrate to Gateway API from Nginx Ingress**
 
-    Nginx Ingress will be removed and Envoy Gateway be created instead. That might cause a downtime while DNS is propagated from Nginx Ingress to Gateway IP address. If the downtime is not acceptable, consider deploying a new regional cluster with Gateway API and following the [migration to a new cluster](kof-upgrade.md#data-migration-to-a-new-regional-cluster)
+    Nginx Ingress will be removed and Envoy Gateway be created instead. That might cause a downtime while DNS is propagated from Nginx Ingress to Gateway IP address. If the downtime is not acceptable, consider deploying a new regional cluster with Gateway API and following the [migration to a new cluster](../docs/admin/kof/kof-upgrade.md#data-migration-to-a-new-regional-cluster)
 
     Update kof-values.yaml:
 
@@ -29,9 +29,9 @@ KOF v1.9.0 introduces a [Gateway API](http://gateway-api.sigs.k8s.io/) support.
               enabled: true
         ```
 
-    If you are using [DNS auto-config](./kof-install.md#dns-auto-config) DNS will be switched automatically.
+    If you are using [DNS auto-config](../docs/admin/kof/kof-install.md#dns-auto-config) DNS will be switched automatically.
 
-    In case of [Manual DNS config](./kof-verification.md#manual-dns-config), apply gateway address.
+    In case of [Manual DNS config](../docs/admin/kof/kof-verification.md#manual-dns-config), apply gateway address.
 
 
 3. **Upgrade the umbrella chart**:


### PR DESCRIPTION
* OpenCost logs spam with `Error getting LoadBalancer cost: strconv.ParseFloat: parsing "": invalid syntax`
  when we use OpenStack and other `Unsupported provider, falling back to default`:
  * Upstream issue: https://github.com/opencost/opencost/issues/2925
  * Buggy code: https://github.com/opencost/opencost/blob/v1.118.0/pkg/cloud/provider/customprovider.go#L298-L311
* The workaround is to set non-empty LoadBalancer costs.
* This also requires to enable custom pricing:
  * Deployment uses ConfigMap in this case: https://github.com/opencost/opencost-helm-chart/blob/opencost-2.4.0/charts/opencost/templates/deployment.yaml#L279
  * ConfigMap with custom pricing: https://github.com/opencost/opencost-helm-chart/blob/opencost-2.4.0/charts/opencost/templates/configmap-custom-pricing.yaml#L10
* We want dynamic pricing from the provider API for AWS and other providers supported by OpenCost,
  so enabling static custom pricing by default is a bad idea.
* So this workaround should be applied conditionally in the docs (for now),
  especially as the cost of RAM and other resources should also be set for provider unsupported by OpenCost,
  and we don't know user-specific costs.

<img width="701" height="402" alt="Screenshot 2026-04-14 at 18 09 10" src="https://github.com/user-attachments/assets/307eaf54-fcf5-47b0-b3a7-f4a6e2fe0ed0" />
