### PR TITLE
docs: KOF 1.9.0

### DIFF
--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -330,11 +330,11 @@ and apply this example, or use it as a reference:
 8. Install the KOF umbrella chart, which orchestrates the installation of
     operators, mothership, and shared config for all regional and child clusters:
 
-{%
-    include-markdown "../../../includes/kof-install-includes.md"
-    start="<!--install-kof-start-->"
-    end="<!--install-kof-end-->"
-%}
+    {%
+        include-markdown "../../../includes/kof-install-includes.md"
+        start="<!--install-kof-start-->"
+        end="<!--install-kof-end-->"
+    %}
 
     The chart uses FluxCD to manage sequential deployment of all KOF components.
     

--- a/includes/kof-install-includes.md
+++ b/includes/kof-install-includes.md
@@ -8,7 +8,7 @@
     ```bash
     helm upgrade -i --reset-values --wait --create-namespace -n istio-system k0rdent-istio \
       {{{ docsVersionInfo.kofVersions.kofOciRegistryBaseIstio }}}/charts/k0rdent-istio \
-      --version 0.4.0 \
+      --version 0.5.0 \
       --set cert-manager-service-template.enabled=false \
       --set "istiod.meshConfig.extensionProviders[0].name=otel-tracing" \
       --set "istiod.meshConfig.extensionProviders[0].opentelemetry.port=4317" \

--- a/includes/kof-install-includes.md
+++ b/includes/kof-install-includes.md
@@ -19,7 +19,7 @@
 
 <!--install-kof-start-->
   ```bash
-  helm upgrade -i --reset-values --wait \
+  helm upgrade -i --reset-values \
     --create-namespace -n kof kof \
     -f kof-values.yaml \
     {{{ docsVersionInfo.kofVersions.kofOciRegistryBase }}}/charts/kof \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -373,7 +373,7 @@ extra:
     k0rdentDigestDate: Tue Mar 03 12:54:32 2026
     k0rdentTagList: https://github.com/k0rdent/kcm/tags
     kofVersions:
-      kofDotVersion: 1.8.0
+      kofDotVersion: 1.9.0
       kofOciRegistryBase: oci://ghcr.io/k0rdent/kof
       kofOciRegistryBaseIstio: oci://ghcr.io/k0rdent/istio
     providerVersions:


### PR DESCRIPTION
* Bump to KOF 1.9.0 and k/istio 0.5.0.
* Deleted `--wait` from umbrella chart installation to show the [NOTES](https://github.com/k0rdent/kof/blob/v1.9.0-rc1/charts/kof/templates/NOTES.txt) even if installation fails. We wait for `helmreleases` as the next step anyway.
* Fixed indentation of markdown include:

| Before | After |
| --- | --- |
| <img width="723" height="361" alt="Screenshot 2026-04-24 at 22 47 45" src="https://github.com/user-attachments/assets/31b04185-7256-4fdf-bc07-fbe0cdd5401e" /> | <img width="723" height="309" alt="Screenshot 2026-04-24 at 22 48 04" src="https://github.com/user-attachments/assets/c8699fb0-27b4-4423-9930-b5925f07c23f" /> |
