### PR TITLE
docs: update openstack credential examples

### DIFF
--- a/docs/admin/installation/prepare-mgmt-cluster/openstack.md
+++ b/docs/admin/installation/prepare-mgmt-cluster/openstack.md
@@ -8,7 +8,7 @@
 
 2. OpenStack CLI (optional)
 
-    If you plan to access OpenStack directly, go ahead and 
+    If you plan to access OpenStack directly, go ahead and
     [install the OpenStack CLI](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html).
 
 3. Configure the OpenStack Application Credential
@@ -55,7 +55,7 @@
     ```
 
     > NOTE:
-    > The name of the `Secret` must follow a specific pattern. See [credential secret](../../../appendix/appendix-providers.md#credential-secret) for details. 
+    > The name of the `Secret` must follow a specific pattern. See [credential secret](../../../appendix/appendix-providers.md#credential-secret) for details.
 
     Apply the YAML to your cluster:
 
@@ -91,7 +91,7 @@
     kubectl apply -f openstack-cluster-identity-cred.yaml
     ```
 
-    Note that `.spec.identityRef.name` must match the `Secret` you created in the previous step, and 
+    Note that `.spec.identityRef.name` must match the `Secret` you created in the previous step, and
     `.spec.identityRef.namespace` must be the same as the one that includes the `Secret` (`kcm-system`).
 
 6. Create the ConfigMap resource-template object
@@ -135,6 +135,9 @@
 
         {{- $network_id := $cluster.status.externalNetwork.id -}}
         {{- $network_name := $cluster.status.externalNetwork.name -}}
+
+        {{- $verify := index $openstack "verify" -}}
+        {{- $ca_cert := index $identity "data" "cacert" -}}
         ---
         apiVersion: v1
         kind: Secret
@@ -165,6 +168,14 @@
             {{- end }}
             region="{{ index $openstack "region_name" }}"
 
+            {{- if or (eq $verify false) (eq (lower (printf "%v" $verify)) "false") }}
+            tls-insecure=true
+            {{- end }}
+
+            {{- if $ca_cert }}
+            ca-file=/etc/cacert/ca.crt
+            {{- end }}
+
             [LoadBalancer]
             {{- if $network_id }}
             floating-network-id="{{ $network_id }}"
@@ -174,8 +185,19 @@
             {{- if $network_name }}
             public-network-name="{{ $network_name }}"
             {{- end }}
+        {{- if $ca_cert }}
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: openstack-ca-cert
+          namespace: kube-system
+        type: Opaque
+        data:
+          ca.crt: "{{ $ca_cert }}"
+        {{- end }}
     ```
-    
+
     Apply the YAML to your cluster:
 
     ```bash
@@ -190,6 +212,7 @@
     ```bash
     kubectl get clustertemplate -n kcm-system
     ```
+
     ```console { .no-copy }
     NAME                            VALID
     adopted-cluster-{{{ extra.docsVersionInfo.k0rdentVersion }}}           true
@@ -273,14 +296,16 @@
     ```bash
     kubectl get clusterdeployments -A
     ```
+
     ```console { .no-copy }
     NAMESPACE    NAME                          READY   STATUS
     kcm-system   my-openstack-cluster-deployment   True    ClusterDeployment is ready
     ```
+
     ```bash
     kubectl delete clusterdeployments my-openstack-cluster-deployment -n kcm-system
     ```
+
     ```console { .no-copy }
     clusterdeployment.k0rdent.mirantis.com "my-openstack-cluster-deployment" deleted
     ```
-

--- a/docs/quickstarts/quickstart-2-openstack.md
+++ b/docs/quickstarts/quickstart-2-openstack.md
@@ -313,21 +313,29 @@ data:
   configmap.yaml: |
     {{- $cluster := .InfrastructureProvider -}}
     {{- $identity := (getResource "InfrastructureProviderIdentity") -}}
+
     {{- $clouds := fromYaml (index $identity "data" "clouds.yaml" | b64dec) -}}
     {{- if not $clouds }}
       {{ fail "failed to decode clouds.yaml" }}
     {{ end -}}
+
     {{- $openstack := index $clouds "clouds" "openstack" -}}
+
     {{- if not (hasKey $openstack "auth") }}
       {{ fail "auth key not found in openstack config" }}
     {{- end }}
     {{- $auth := index $openstack "auth" -}}
+
     {{- $auth_url := index $auth "auth_url" -}}
     {{- $app_cred_id := index $auth "application_credential_id" -}}
     {{- $app_cred_name := index $auth "application_credential_name" -}}
     {{- $app_cred_secret := index $auth "application_credential_secret" -}}
+
     {{- $network_id := $cluster.status.externalNetwork.id -}}
     {{- $network_name := $cluster.status.externalNetwork.name -}}
+
+    {{- $verify := index $openstack "verify" -}}
+    {{- $ca_cert := index $identity "data" "cacert" -}}
     ---
     apiVersion: v1
     kind: Secret
@@ -339,28 +347,53 @@ data:
       cloud.conf: |
         [Global]
         auth-url="{{ $auth_url }}"
+
         {{- if $app_cred_id }}
         application-credential-id="{{ $app_cred_id }}"
         {{- end }}
+
         {{- if $app_cred_name }}
         application-credential-name="{{ $app_cred_name }}"
         {{- end }}
+
         {{- if $app_cred_secret }}
         application-credential-secret="{{ $app_cred_secret }}"
         {{- end }}
+
         {{- if and (not $app_cred_id) (not $app_cred_secret) }}
         username="{{ index $openstack "username" }}"
         password="{{ index $openstack "password" }}"
         {{- end }}
         region="{{ index $openstack "region_name" }}"
+
+        {{- if or (eq $verify false) (eq (lower (printf "%v" $verify)) "false") }}
+        tls-insecure=true
+        {{- end }}
+
+        {{- if $ca_cert }}
+        ca-file=/etc/cacert/ca.crt
+        {{- end }}
+
         [LoadBalancer]
         {{- if $network_id }}
         floating-network-id="{{ $network_id }}"
         {{- end }}
+
         [Networking]
         {{- if $network_name }}
         public-network-name="{{ $network_name }}"
         {{- end }}
+    {{- if $ca_cert }}
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openstack-ca-cert
+      namespace: kube-system
+    type: Opaque
+    data:
+      ca.crt: "{{ $ca_cert }}"
+    {{- end }}
 ```
 
 Apply the YAML to your cluster:
@@ -537,9 +570,9 @@ Now that you've finished the {{{ docsVersionInfo.k0rdentName }}} QuickStart, we 
 
 Check out the [Administrator Guide](../admin/index.md) ...
 
-* For a more detailed view of {{{ docsVersionInfo.k0rdentName }}} setup for production
-* For details about setting up {{{ docsVersionInfo.k0rdentName }}} to manage clusters on VMware
-* For details about using {{{ docsVersionInfo.k0rdentName }}} with cloud Kubernetes distros such as AWS EKS, Azure AKS, and Google Kubernetes Engine
+- For a more detailed view of {{{ docsVersionInfo.k0rdentName }}} setup for production
+- For details about setting up {{{ docsVersionInfo.k0rdentName }}} to manage clusters on VMware
+- For details about using {{{ docsVersionInfo.k0rdentName }}} with cloud Kubernetes distros such as AWS EKS, Azure AKS, and Google Kubernetes Engine
 
 <!--
 Or check out the [Demos Repository](https://github.com/k0rdent/demos) for fast, makefile-driven demos of {{{ docsVersionInfo.k0rdentName }}}'s key features.


### PR DESCRIPTION
Updates OpenStack's examples with credentials syncing with the up-to-date state.

Must be migrated/synced to the EE documentation.

Related-To: https://github.com/k0rdent/kcm/issues/977