### PR TITLE
docs(templates): etcd encryption on rest

### DIFF
--- a/docs/reference/template/template-aws.md
+++ b/docs/reference/template/template-aws.md
@@ -85,6 +85,12 @@ spec:
    and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
    string, such as `--some-flag=argument`.
 
+## Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
+
 ## EKS templates
 
 > WARNING:

--- a/docs/reference/template/template-azure.md
+++ b/docs/reference/template/template-azure.md
@@ -97,3 +97,9 @@ By default, the latest official CAPZ Ubuntu based image is used.
 * `k0smotron.controllerPlaneFlags` <sup>only hosted</sup> (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
    and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
    string, such as `--some-flag=argument`.
+
+## Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}

--- a/docs/reference/template/template-gcp.md
+++ b/docs/reference/template/template-gcp.md
@@ -60,6 +60,12 @@ Available for the hosted cluster template only.
    and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
    string, such as `--some-flag=argument`.
 
+### Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
+
 ### Extensions parameters
 
 * `extensions.chartRepository` (string): Custom Helm repository.

--- a/docs/reference/template/template-kubevirt.md
+++ b/docs/reference/template/template-kubevirt.md
@@ -5,10 +5,16 @@
 To create a cluster deployment, you must provide a set of parameters to the `ClusterDeployment` object.
 The full list of parameters is defined in the corresponding Helm chart for the Cluster Template you use. For
 built‑in KubeVirt Cluster Templates, refer to the
-[Cluster Templates](https://github.com/k0rdent/kcm/tree/v{{{ extra.docsVersionInfo.k0rdentDotVersion }}}/templates/cluster)
+[Cluster Templates](<https://github.com/k0rdent/kcm/tree/v{{{ extra.docsVersionInfo.k0rdentDotVersion }}}/templates/cluster>)
 section of the `k0rdent/kcm` repository.
 
 The KubeVirt API is documented in the [KubeVirt API Reference](https://kubevirt.io/api-reference/).
+
+### Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
 
 ### Data Volumes
 

--- a/docs/reference/template/template-openstack.md
+++ b/docs/reference/template/template-openstack.md
@@ -73,13 +73,19 @@ If your user doesn't have access to or your cloud doesn't utilize octavia load b
    See: <https://docs.k0sproject.io/stable/cli/k0s_controller>.
 - `k0s.workerArgs` (array of strings): A list of extra arguments for configuring the k0s worker node. See: <https://docs.k0sproject.io/stable/cli/k0s_worker>.
 
+### Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
+
 ### Hosted ClusterDeployment parameters
 
 #### Network configuration
 
 The following parameters under `spec.config` are specific to the hosted cluster deployment:
 
-* `network.filter` (object): Specifies a query to select an OpenStack network. The value of [NetworkFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkFilter) type. Required.
+- `network.filter` (object): Specifies a query to select an OpenStack network. The value of [NetworkFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkFilter) type. Required.
 
     Example:
 
@@ -89,7 +95,7 @@ The following parameters under `spec.config` are specific to the hosted cluster 
           name: my-network-name
     ```
 
-* `subnets[].filter` (array): Specifies a query to select an OpenStack subnet. The value of [SubnetFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.SubnetFilter) type. Required.
+- `subnets[].filter` (array): Specifies a query to select an OpenStack subnet. The value of [SubnetFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.SubnetFilter) type. Required.
 
     Example:
 
@@ -99,7 +105,7 @@ The following parameters under `spec.config` are specific to the hosted cluster 
           name: my-subnet-name
     ```
 
-* `router.filter` (object): Specifies a query to select an OpenStack router. The value of [RouterFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.RouterFilter) type. Required.
+- `router.filter` (object): Specifies a query to select an OpenStack router. The value of [RouterFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.RouterFilter) type. Required.
 
     Example:
 
@@ -109,7 +115,7 @@ The following parameters under `spec.config` are specific to the hosted cluster 
           name: my-router-name
     ```
 
-* `ports[].network.filter` (object): Specifies a query to select an OpenStack network. The value of [NetworkFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkFilter) type. Required.
+- `ports[].network.filter` (object): Specifies a query to select an OpenStack network. The value of [NetworkFilter](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.NetworkFilter) type. Required.
 
     Example:
 
@@ -120,10 +126,11 @@ The following parameters under `spec.config` are specific to the hosted cluster 
             name: my-network-name
     ```
 
-* `managedSecurityGroups` (object): Defines the desired state of security groups and rules for the cluster. When not
+- `managedSecurityGroups` (object): Defines the desired state of security groups and rules for the cluster. When not
   defined, security groups will not be created. The value of [ManagedSecurityGroups](https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.ManagedSecurityGroups) type.
 
     Example:
+
     ```yaml
       managedSecurityGroups:
         allowAllInClusterTraffic: false
@@ -133,10 +140,10 @@ The following parameters under `spec.config` are specific to the hosted cluster 
 
 Available for the hosted cluster template only.
 
-* `k0smotron.service.type` (string): An ingress method for a service. One of: `ClusterIP`, `NodePort`, `LoadBalancer`. Defaults to: `LoadBalancer`.
-* `k0smotron.service.apiPort` (number): The Kubernetes API port. If empty, K0smotron will pick it automatically.
-* `k0smotron.service.konnectivityPort` (number): The Konnectivity port. If empty, K0smotron will pick it automatically.
-* `k0smotron.controllerPlaneFlags` (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
+- `k0smotron.service.type` (string): An ingress method for a service. One of: `ClusterIP`, `NodePort`, `LoadBalancer`. Defaults to: `LoadBalancer`.
+- `k0smotron.service.apiPort` (number): The Kubernetes API port. If empty, K0smotron will pick it automatically.
+- `k0smotron.service.konnectivityPort` (number): The Konnectivity port. If empty, K0smotron will pick it automatically.
+- `k0smotron.controllerPlaneFlags` (array of strings): The `controllerPlaneFlags` parameter enables you to configure additional flags for the k0s control plane
   and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
   string, such as `--some-flag=argument`.
 

--- a/docs/reference/template/template-remote.md
+++ b/docs/reference/template/template-remote.md
@@ -32,6 +32,12 @@ To deploy a cluster using {{{ docsVersionInfo.k0rdentName}}} on any SSH accessib
 * `k0smotron.service.apiPort` (number): This parameter defines the port for accessing the Kubernetes API server. Example: `30443`.
 * `k0smotron.service.konnectivityPort` (number): This parameter indicates the port for the Konnectivity service. Example: `30132`.
 
+### Etcd encryption at rest for remote template
+
+{%
+    include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
+
 ### K0s Parameters
 
 * `k0s.version` (string): Specifies the version of the k0s Kubernetes distribution. Example: `"v1.32.2+k0s.0"`.

--- a/docs/reference/template/template-vsphere.md
+++ b/docs/reference/template/template-vsphere.md
@@ -68,6 +68,12 @@ govc vm.info -t '*'
    and to override existing flags. The default flags are kept unless they are explicitly overriden. Flags with arguments must be specified as a single
    string, such as `--some-flag=argument`.
 
+### Etcd encryption at rest for hosted and standalone templates
+
+{%
+  include-markdown "../../../includes/template-encryption-at-rest.md"
+%}
+
 ## Example of a ClusterDeployment CR
 
 With all above parameters provided your `ClusterDeployment` can look like this:

--- a/includes/template-encryption-at-rest.md
+++ b/includes/template-encryption-at-rest.md
@@ -1,0 +1,37 @@
+To enable Kubernetes API encryption at rest, configure these parameters under `.spec.config.encryption`:
+
+* `automaticReload` (boolean): Enables `kube-apiserver` automatic reload for
+  the encryption provider config (default: `true`).
+* `configSecret.name` (string): Name of the Secret containing
+  `EncryptionConfiguration`.
+* `configSecret.key` (string): Secret data key with `EncryptionConfiguration`
+  YAML (default: `config`).
+* `configSecret.hash` (string): Optional hash suffix for the mounted file name.
+  If empty, it is calculated automatically from the Secret data using Helm
+  `lookup`.
+
+The controller configures `kube-apiserver` with:
+
+* `--encryption-provider-config=<path>`
+* `--encryption-provider-config-automatic-reload=true` (when `automaticReload=true`)
+
+Hash calculation behavior:
+
+* If `configSecret.hash` is set, that value is used.
+* If `configSecret.hash` is empty, the chart tries to calculate a hash from
+  `Secret.data[configSecret.key]` in the `ClusterDeployment` namespace.
+* If lookup cannot read the Secret during rendering, the chart falls back to
+  `config.yaml`.
+
+Secret placement rules:
+
+* The Secret must exist in the same namespace as the `ClusterDeployment`.
+* If `Credential.spec.region` is not set, create the Secret in the management
+  cluster.
+* If `Credential.spec.region` is set, create the Secret in the regional cluster.
+* The encryption Secret is not copied automatically between management and
+  regional clusters.
+
+> NOTE:
+> Enabling encryption at rest affects newly written data. Existing etcd objects
+> are not re-encrypted automatically and require a rewrite/migration procedure.


### PR DESCRIPTION
Documents new changes enabling etcd encryption introduced by https://github.com/k0rdent/kcm/pull/2704

Must be migrated/synced to the EE documentation.

Related-To: https://github.com/k0rdent/kcm/issues/976