### PR TITLE
docs: KOF: Replacing long docs "From Management to Regional" with automatic `fromManagement.toRegionalCluster` switch

### DIFF
--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -278,6 +278,20 @@ and apply this example, or use it as a reference:
     of the `kof` umbrella chart, and more detailed default values of other [charts](https://github.com/k0rdent/kof/tree/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts),
     to customize your `kof-values.yaml` file where needed, for example:
 
+    ??? note "If your management cluster does not have [metrics-server](https://kubernetes-sigs.github.io/metrics-server/):"
+
+        E.g. [k0s](https://k0sproject.io/) provides it,
+        [kind](https://kind.sigs.k8s.io/) does not, but you can install it:
+
+        ```yaml
+        kof-mothership:
+          values:
+            metrics-server:
+              enabled: true
+              args:
+                - --kubelet-insecure-tls
+        ```
+
     ??? note "If your regional clusters already have `cert-manager` and `envoy-gateway`, disable them in KOF:"
 
         ```yaml

--- a/docs/admin/kof/kof-storing.md
+++ b/docs/admin/kof/kof-storing.md
@@ -70,15 +70,17 @@ To apply this option:
                     clusterNamespace: kcm-system
     ```
 
-    ??? note "If you're using `kind` for Management cluster, merge this:"
+    ??? note "If your management cluster is not [k0s](https://k0sproject.io/):"
+
+        KOF scrapes `etcd` metrics using cert files like
+        `/hostfs/${env:PKI_PATH}/pki/apiserver-etcd-client.crt`
+
+        If you have `PKI_PATH` other than `var/lib/k0s`,
+        e.g. when testing with [kind](https://kind.sigs.k8s.io/), merge this:
 
         ```yaml
         kof-collectors:
           values:
-            metrics-server:
-              enabled: true
-              args:
-                - "--kubelet-insecure-tls"
             opentelemetry-kube-stack:
               defaultCRConfig:
                 env:
@@ -107,311 +109,42 @@ To apply this option:
 
 ## From Management to Regional
 
-This option stores KOF data of the management cluster in the regional cluster.
-
-It assumes that:
-
-* You did not enable Istio.
-* You have a regional cluster with the `REGIONAL_DOMAIN` configured [here](./kof-install.md#regional-cluster).
+This option stores KOF data of the management cluster in the regional cluster
+with the `REGIONAL_CLUSTER_NAME` configured [here](./kof-install.md#regional-cluster).
 
 To apply this option:
 
-1. Run in the management cluster:
-    ```bash
-    VMUSER_CREDS_NAME=$(
-      kubectl get secret -n kof \
-      | grep vmuser-creds-admin \
-      | cut -d ' ' -f 1
-    )
-    echo $VMUSER_CREDS_NAME
-    ```
-
-2. Create the patch:
+1. Create the patch:
     ```bash
     cat <<EOF
-    kof-collectors:
-      enabled: true
+    kof-child:
       values:
-        kcm:
-          monitoring: true
-        opentelemetry-kube-stack:
-          clusterName: mothership
-          collectors:
-            daemon:
-              hostNetwork: true
-              observability:
-                metrics:
-                  disablePrometheusAnnotations: false
-                  enableMetrics: false
-              podAnnotations:
-                prometheus.io/ip4: \${env:OTEL_K8S_NODE_IP}
-              config:
-                receivers:
-                  prometheus:
-                    api_server:
-                      server_config:
-                        endpoint: \${env:OTEL_K8S_NODE_IP}:9090
-                  otlp:
-                    protocols:
-                      grpc:
-                        endpoint: 0.0.0.0:4317
-                      http:
-                        endpoint: 0.0.0.0:4318
-                service:
-                  extensions:
-                    - k8s_observer
-                    - file_storage/filelogreceiver
-                    - file_storage/filelogsyslogreceiver
-                    - file_storage/filelogk8sauditreceiver
-                    - file_storage/journaldreceiver
-                    - basicauth/metrics
-                    - basicauth/logs
-                    - basicauth/traces
-                  telemetry:
-                    metrics:
-                      readers:
-                        - pull:
-                            exporter:
-                              prometheus:
-                                host: \${env:OTEL_K8S_NODE_IP}
-                                port: 8888
-          defaultCRConfig:
-            env:
-              - name: PKI_PATH
-                value: var/lib/k0s
-              - name: KOF_VM_USER
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: $VMUSER_CREDS_NAME
-              - name: KOF_VM_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: $VMUSER_CREDS_NAME
-            config:
-              processors:
-                resource/k8sclustername:
-                  attributes:
-                    - action: insert
-                      key: k8s.cluster.name
-                      value: mothership
-                    - action: insert
-                      key: k8s.cluster.namespace
-                      value: kcm-system
-              extensions:
-                basicauth/metrics:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-                basicauth/logs:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-                basicauth/traces:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-              exporters:
-                prometheusremotewrite:
-                  endpoint: https://vmauth.$REGIONAL_DOMAIN/vm/insert/0/prometheus/api/v1/write
-                  auth:
-                    authenticator: basicauth/metrics
-                  external_labels:
-                    cluster: mothership
-                    clusterNamespace: kcm-system
-                otlphttp/logs:
-                  logs_endpoint: https://vmauth.$REGIONAL_DOMAIN/vli/insert/opentelemetry/v1/logs
-                  auth:
-                    authenticator: basicauth/logs
-                otlphttp/traces:
-                  traces_endpoint: https://vmauth.$REGIONAL_DOMAIN/vti/insert/opentelemetry/v1/traces
-                  auth:
-                    authenticator: basicauth/traces
-              service:
-                extensions:
-                  - basicauth/metrics
-                  - basicauth/logs
-                  - basicauth/traces
-        opencost:
-          opencost:
-            prometheus:
-              existingSecretName: $VMUSER_CREDS_NAME
-              external:
-                url: https://vmauth.$REGIONAL_DOMAIN/vm/select/0/prometheus
+        fromManagement:
+          toRegionalCluster:
+            name: $REGIONAL_CLUSTER_NAME
     EOF
     ```
 
-    ??? note "If you're using `kind` for Management cluster, merge this:"
+    ??? note "If your management cluster is not [k0s](https://k0sproject.io/):"
+
+        KOF scrapes `etcd` metrics using cert files like
+        `/hostfs/${env:PKI_PATH}/pki/apiserver-etcd-client.crt`
+
+        If you have `PKI_PATH` other than `var/lib/k0s`,
+        e.g. when testing with [kind](https://kind.sigs.k8s.io/), merge this:
 
         ```yaml
-        kof-collectors:
+        kof-child:
           values:
-            metrics-server:
-              enabled: true
-              args:
-                - "--kubelet-insecure-tls"
-            opentelemetry-kube-stack:
-              defaultCRConfig:
-                env:
-                  - name: PKI_PATH
-                    value: etc/kubernetes
+            fromManagement:
+              collectors:
+                values:
+                  opentelemetry-kube-stack:
+                    defaultCRConfig:
+                      env:
+                        - name: PKI_PATH
+                          value: etc/kubernetes
         ```
-
-        Please merge to the existing `env` list manually to avoid overwrite.
-
-    ??? note "If you create this file directly:"
-
-        * Replace `\$` with `$`,
-        * `$VMUSER_CREDS_NAME` with the value from step 1,
-        * `$REGIONAL_DOMAIN` with the value from [Installing KOF - Regional Cluster](kof-install.md/#regional-cluster).
-
-2. Add this patch to the existing `kof-values.yaml` file
-    and then apply `kof-values.yaml` to the [Management Cluster](kof-install.md/#management-cluster):
-
-{%
-    include-markdown "../../../includes/kof-install-includes.md"
-    start="<!--install-kof-start-->"
-    end="<!--install-kof-end-->"
-%}
-
-## From Management to Regional with Istio
-
-This option stores KOF data of the management cluster in the regional cluster using Istio.
-
-It assumes that:
-
-* You have Istio enabled.
-* You have a regional cluster with the `REGIONAL_CLUSTER_NAME` configured [here](./kof-install.md#regional-cluster).
-
-To apply this option:
-
-1. Run in the management cluster:
-    ```bash
-    VMUSER_CREDS_NAME=$(
-      kubectl get secret -n kof \
-      | grep vmuser-creds-admin \
-      | cut -d ' ' -f 1
-    )
-    echo $VMUSER_CREDS_NAME
-    ```
-
-2. Create the patch:
-    ```bash
-    cat <<EOF
-    kof-collectors:
-      enabled: true
-      values:
-        kcm:
-          monitoring: true
-        opentelemetry-kube-stack:
-          clusterName: mothership
-          collectors:
-            controller-k0s:
-              enabled: false
-            daemon:
-              hostNetwork: false
-              config:
-                service:
-                  extensions:
-                    - k8s_observer
-                    - file_storage/filelogreceiver
-                    - file_storage/filelogsyslogreceiver
-                    - file_storage/filelogk8sauditreceiver
-                    - file_storage/journaldreceiver
-                    - basicauth/metrics
-                    - basicauth/logs
-                    - basicauth/traces
-          defaultCRConfig:
-            env:
-              - name: PKI_PATH
-                value: var/lib/k0s
-              - name: KOF_VM_USER
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: $VMUSER_CREDS_NAME
-              - name: KOF_VM_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: $VMUSER_CREDS_NAME
-            config:
-              processors:
-                resource/k8sclustername:
-                  attributes:
-                    - action: insert
-                      key: k8s.cluster.name
-                      value: mothership
-                    - action: insert
-                      key: k8s.cluster.namespace
-                      value: kcm-system
-              extensions:
-                basicauth/logs:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-                basicauth/metrics:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-                basicauth/traces:
-                  client_auth:
-                    username: \${env:KOF_VM_USER}
-                    password: \${env:KOF_VM_PASSWORD}
-              service:
-                extensions:
-                - basicauth/logs
-                - basicauth/metrics
-                - basicauth/traces
-              exporters:
-                prometheusremotewrite:
-                  endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vm/insert/0/prometheus/api/v1/write
-                  auth:
-                    authenticator: basicauth/metrics
-                  external_labels:
-                    cluster: mothership
-                    clusterNamespace: kcm-system
-                otlphttp/logs:
-                  logs_endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vli/insert/opentelemetry/v1/logs
-                  auth:
-                    authenticator: basicauth/logs
-                otlphttp/traces:
-                  traces_endpoint: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vti/insert/opentelemetry/v1/traces
-                  auth:
-                    authenticator: basicauth/traces
-        opencost:
-          opencost:
-            prometheus:
-              existingSecretName: $VMUSER_CREDS_NAME
-              external:
-                url: http://$REGIONAL_CLUSTER_NAME-vmauth:8427/vm/select/0/prometheus
-    EOF
-    ```
-
-    ??? note "If you're using `kind` for Management cluster, merge this:"
-
-        ```yaml
-        kof-collectors:
-          values:
-            metrics-server:
-              enabled: true
-              args:
-                - "--kubelet-insecure-tls"
-            opentelemetry-kube-stack:
-              defaultCRConfig:
-                env:
-                  - name: PKI_PATH
-                    value: etc/kubernetes
-        ```
-
-        Please merge to the existing `env` list manually to avoid overwrite.
-
-    ??? note "If you create this file directly:"
-
-        * Replace `\$` with `$`,
-        * `$VMUSER_CREDS_NAME` with the value from step 1,
-        * `$REGIONAL_CLUSTER_NAME` with the value from [Installing KOF - Regional Cluster](kof-install.md/#regional-cluster).
 
 2. Add this patch to the existing `kof-values.yaml` file
     and then apply `kof-values.yaml` to the [Management Cluster](kof-install.md/#management-cluster):


### PR DESCRIPTION
* Part of https://github.com/k0rdent/kof/issues/733
* Blocked by https://github.com/k0rdent/kof/pull/1001
* Replaced long docs with small switch:

<img width="717" height="699" alt="Screenshot 2026-05-11 at 18 49 13" src="https://github.com/user-attachments/assets/ce06dea9-cd8f-4158-a21d-f91ee3d9fa4d" />

* Improved `PKI_PATH` wording:

<img width="679" height="310" alt="Screenshot 2026-05-11 at 18 52 37" src="https://github.com/user-attachments/assets/56135ebe-50ab-4994-9dcf-500459d5946a" />

* Moved `metrics-server` to `kof-mothership` installation:

<img width="699" height="487" alt="Screenshot 2026-05-11 at 18 07 20" src="https://github.com/user-attachments/assets/50aa5d55-6ff4-434a-8313-deb9fb14d232" />
