### PR TITLE
docs: add a troubleshooting guide for remote clusters

### DIFF
--- a/docs/quickstarts/quickstart-2-remote.md
+++ b/docs/quickstarts/quickstart-2-remote.md
@@ -4,10 +4,10 @@ In many cases, you will want {{{ docsVersionInfo.k0rdentName }}} (running on you
 
 The remote machines that will be part of the cluster must meet the following prerequisites:
 
-1.	Linux-based operating system; the remote hosts should meet the [k0s system requirements](https://docs.k0sproject.io/stable/system-requirements/)
-2.	SSH access enabled for the root user
-3.	Internet access
-4.	Connectivity between the management cluster and the remote hosts' networks
+1. A Linux-based operating system. All remote hosts must satisfy the [k0s system requirements](https://docs.k0sproject.io/stable/system-requirements/).
+2. SSH access must be enabled for the root user, and the SSH key must be correctly configured and authorized on all remote machines.
+3. Internet connectivity must be available on all remote machines.
+4. Network connectivity must exist between the management cluster and the remote hosts’ networks.
 
 If you haven't yet created a management node and installed k0rdent, go back to [QuickStart 1 - Management node and cluster](quickstart-1-mgmt-node-and-cluster.md).
 
@@ -15,12 +15,19 @@ Note that if you have already done one of the other quickstarts, such as our AWS
 
 Before proceeding, make sure your management cluster meets the following requirements:
 
-1. A [default storage class](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) is configured on the management cluster to support Persistent Volumes.
-2. If the API server will be exposed as a `LoadBalancer`, ensure the appropriate cloud provider is installed on the management cluster.
+1. CSI provider installed and properly configured for persistent storage to support Persistent Volumes.
+2. A [default storage class](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) is configured on the management cluster.
+2. If the API server will be exposed as a `LoadBalancer` (default), ensure the appropriate cloud provider is installed on the management cluster.
 
 ## Create a Secret object containing the private SSH key to access remote machines
 
-Create a `Secret` object to securely store the private SSH key, under the key `value`, for accessing all remote machines that will be part of the cluster. Start by setting the following environment variables, for example by adding them to an `.env` file and sourcing it. (Make sure to either update the `KEY_PATH` to point to the keyfile or enter the directly under `PRIVATE_SSH-KEY_B64`.)
+Create a `Secret` object to securely store the private SSH key, under the key `value`, for accessing all remote
+machines that will be part of the cluster. Start by setting the following environment variables, for example by
+adding them to an `.env` file and sourcing it. (Make sure to either update the `KEY_PATH` to point to the keyfile or
+enter the directly under `PRIVATE_SSH-KEY_B64`).
+
+> NOTE:
+> The SSH key must be configured and authorized on all remote machines that will be part of the cluster.
 
 ```bash
 # Setup Environment
@@ -252,6 +259,11 @@ kubectl delete ClusterDeployment my-remote-clusterdeployment1 -n kcm-system
 ```console { .no-copy }
 clusterdeployment.k0rdent.mirantis.com "my-remote-clusterdeployment1" deleted
 ```
+
+## Troubleshooting
+
+If you encounter any issues during the deployment process, check out the [Troubleshooting guide](../troubleshooting/known-issues-remote.md)
+for steps to debug and known issues related to remote cluster deployments.
 
 ## Next Steps
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -8,5 +8,6 @@ things run smoothly.
 - [EKS](known-issues-eks.md)
 - [GCP](known-issues-gcp.md)
 - [KubeVirt](known-issues-kubevirt.md)
+- [Remote](known-issues-remote.md)
 - [Custom CA Certificates](known-issues-custom-ca.md)
 - [ClusterCtl Issues](known-issues-clusterctl.md)

--- a/docs/troubleshooting/known-issues-kubevirt.md
+++ b/docs/troubleshooting/known-issues-kubevirt.md
@@ -2,7 +2,7 @@
 
 ## Steps to Debug KubeVirt Cluster Deployments
 
-1. Check the `ClusterDeployment` status condition on the management or regional cluster:
+1. Check the `ClusterDeployment` status condition on the management cluster:
 
     ```bash
     kubectl -n $CLUSTER_NAMESPACE get clusterdeployment.k0rdent.mirantis.com $CLUSTER_NAME -o=jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq

--- a/docs/troubleshooting/known-issues-remote.md
+++ b/docs/troubleshooting/known-issues-remote.md
@@ -1,0 +1,112 @@
+# Troubleshooting
+
+## Steps to Debug Remote Cluster Deployments
+
+1. Check the `ClusterDeployment` status condition on the management cluster:
+
+    ```bash
+    kubectl -n $CLUSTER_NAMESPACE get clusterdeployment.k0rdent.mirantis.com $CLUSTER_NAME -o=jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq
+    ```
+
+1. Check the `RemoteMachine` status condition on the management or regional cluster:
+
+    ```bash
+    kubectl -n $CLUSTER_NAMESPACE get remotemachine $CLUSTER_NAME -o=jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq
+    ```
+
+1. In case of worker provisioning issues, check the logs of the k0smotron infrastructure controller pod on
+the management or regional cluster:
+
+    ```bash
+    kubectl -n $SYSTEM_NAMESPACE logs -l k0smotron-provider=infrastructure --tail=-1 | grep "fail\|error"
+    ```
+
+1. If needed, SSH into the VM to check system or k0s logs:
+
+    For k0s logs:
+
+    ```bash
+    sudo journalctl -u k0sworker
+    ```
+
+    For container logs, see the `/var/log/containers` directory. For more information, see [k0s troubleshooting](https://docs.k0sproject.io/v1.34.3+k0s.0/troubleshooting/logs/).
+
+
+# Known Issues
+
+## The ClusterDeployment provisioning is stuck with `Control plane not yet initialized` status
+
+Ensure that all the prerequisites for the remote cluster deployment have been met, especially the following:
+
+* When using the LoadBalancer k0smotron service type, the Cloud Controller Manager must be installed and working on
+the management or regional cluster (when the cluster is deployed in a region).
+
+    To troubleshoot LoadBalancer provisioning, check the following on the management or regional cluster:
+
+    ```bash
+    kubectl -n $CLUSTER_NAMESPACE get services kmc-$CLUSTER_NAME-lb
+    ```
+
+    If the service is stuck in `Pending` state, ensure that the Cloud Controller Manager is installed and properly configured.
+    Check the logs of the Cloud Controller Manager for any issues.
+
+* The storage solution must be configured and working properly.
+
+    To troubleshoot storage provisioning, check the following on the management or regional cluster:
+
+    ```bash
+    kubectl -n $CLUSTER_NAMESPACE get pvc -l cluster.x-k8s.io/cluster-name=$CLUSTER_NAME
+    ```
+
+    If the PVCs are stuck in `Pending` state, ensure that the storage solution is properly configured and working.
+    Check the logs of the storage provisioner for any issues.
+
+
+## RemoteMachine error: `open /etc/k0s.token: invalid argument: failed to stat parent directory`
+
+This issue typically occurs when using an unsupported target operating system (e.g., Ubuntu 26.04). Ensure you
+are running only supported operating systems: Ubuntu 20.04, 22.04, or 24.04. For details, see
+[k0s System Requirements](https://docs.k0sproject.io/v1.35.4+k0s.0/system-requirements/#host-operating-system).
+
+
+## Control plane pods are in CrashLoopBackOff state with `no matches for kind "Chart" in group "helm.k0sproject.io"` error
+
+Ensure you are using k0s version >= `v1.35.4+k0s.0`. This version contains multiple fixes related to Helm.
+
+When using the default `remote-cluster` ClusterTemplate, you can configure the k0s version by setting
+the `spec.config.k0s.version` field in the `ClusterDeployment` object. For example:
+
+```yaml
+config:
+  k0s:
+    version: v1.35.4+k0s.0
+```
+
+## Control plane pods are in CrashLoopBackOff: `too many open files` error
+
+This issue typically occurs when the `fs.inotify` limits are set to a low value on the cluster that hosts control plane
+components (either management or regional).
+
+Ensure that the `fs.inotify` limits are properly configured. For example, when your management or regional cluster
+is running k0s, do the following on your control plane nodes:
+
+1. Add the following lines to a new `*.conf` file (e.g., `inotify-watch.conf`) under the `/etc/sysctl.d/` directory:
+
+    ```bash
+    fs.inotify.max_user_watches=524288
+    fs.inotify.max_user_instances=512
+    ```
+
+1. Apply the changes:
+
+    ```bash
+    sudo sysctl -p --system
+    ```
+
+1. Restart the control plane pods:
+
+    ```bash
+    kubectl -n $CLUSTER_NAMESPACE delete pods -l cluster.x-k8s.io/cluster-name=$CLUSTER_NAME -l app.kubernetes.io/component=control-plane
+    ```
+
+Related to: [New hosted control plane pods are in CrashLoopBackOff](https://docs.k0smotron.io/stable/troubleshooting/#new-hosted-control-plane-pods-are-in-crashloopbackoff).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -282,6 +282,7 @@ nav:
     - AWS VPCs: troubleshooting/admin-troubleshooting-aws-vpcs.md
     - EKS: troubleshooting/known-issues-eks.md
     - GCP: troubleshooting/known-issues-gcp.md
+    - Remote: troubleshooting/known-issues-remote.md
     - KubeVirt: troubleshooting/known-issues-kubevirt.md
     - Custom CA Certificates: troubleshooting/known-issues-custom-ca.md
     - Clusterctl Issues: troubleshooting/known-issues-clusterctl.md


### PR DESCRIPTION
Additionally contains some minor quick start guide clarifications.

Applies to all k0rdent releases, including enterprise. 

Fixes #788