### PR TITLE
docs: KOF: Remove `kof-storage/kof-collectors` from `kof` umbrella chart in favor of M2M MCS

### DIFF
--- a/docs/admin/kof/kof-architecture.md
+++ b/docs/admin/kof/kof-architecture.md
@@ -119,12 +119,10 @@ To update the diagram:
     kof-operator
     promxy
 
-  kof-collectors chart
-    opencost
-    opentelemetry-kube-stack
-
   kof-regional and kof-child
     MultiClusterServices
+
+  Optional kof-storage and kof-collectors charts
 
 Cloud 1..N
   Region 1..M
@@ -210,19 +208,13 @@ Cloud 1..N
     </div>
   </div>
   <div class="o">
-    kof-collectors chart
-    <div class="o">
-      opencost
-    </div>
-    <div class="o">
-      opentelemetry-kube-stack
-    </div>
-  </div>
-  <div class="o">
     kof-regional and kof-child
     <div class="o">
       MultiClusterServices
     </div>
+  </div>
+  <div class="o">
+    Optional kof-storage and kof-collectors charts
   </div>
 </div>
 <div class="o">
@@ -252,10 +244,10 @@ Cloud 1..N
           victoria-logs-cluster
         </div>
         <div class="o">
-          external-dns
+          victoria-traces-cluster
         </div>
         <div class="o">
-          victoria-traces-cluster
+          external-dns
         </div>
         <div class="o">
           dex
@@ -357,6 +349,7 @@ Cloud 1..N
 
 - [MultiClusterService](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-child/templates/child-multi-cluster-service.yaml)
   which configures and installs `kof-collectors` and other charts to child clusters
+  and [optionally](kof-storing.md) to the management cluster
 
 ### kof-storage
 

--- a/docs/admin/kof/kof-install.md
+++ b/docs/admin/kof/kof-install.md
@@ -646,7 +646,7 @@ apply this example for AWS, or use it as a reference:
         k0rdent.mirantis.com/kof-http-config: '{"dial_timeout": "10s", "tls_config": {"insecure_skip_verify": true}}'
         ```
 
-10. `MultiClusterService` named [kof-regional-cluster](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-regional/templates/regional-multi-cluster-service.yaml) configure and install `cert-manager`, `ingress-nginx`, `kof-operators`, `kof-storage`, and `kof-collectors` charts automatically.
+10. `MultiClusterService` named [kof-regional-cluster](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-regional/templates/regional-multi-cluster-service.yaml) configure and install `cert-manager`, `envoy-gateway` or `ingress-nginx`, `kof-operators`, `victoria-metrics-operator`, `kof-storage`, and `kof-collectors` charts automatically.
 
     To pass any custom [values](https://github.com/k0rdent/kof/blob/v{{{ extra.docsVersionInfo.kofVersions.kofDotVersion }}}/charts/kof-storage/values.yaml)
     to the `kof-storage` chart or its subcharts, such as [victoria-logs-cluster](https://docs.victoriametrics.com/helm/victorialogs-cluster/#parameters),


### PR DESCRIPTION
* Docs for https://github.com/k0rdent/kof/pull/1030
* Also replaces one missed "`ingress-nginx`" with "`envoy-gateway` or `ingress-nginx`".