### PR TITLE
docs: drop kind and APIServer from ClusterAuthentication spec

### DIFF
--- a/docs/admin/clusters/cluster-iam-setup.md
+++ b/docs/admin/clusters/cluster-iam-setup.md
@@ -24,8 +24,6 @@ metadata:
   namespace: my-namespace
 spec:
   authenticationConfiguration:
-    apiVersion: apiserver.config.k8s.io/v1beta1
-    kind: AuthenticationConfiguration
     jwt:
       - issuer:
           url: https://dex.example.com:5556
@@ -53,7 +51,7 @@ This configuration authenticates users based on email addresses and propagates g
 
 * **`spec.authenticationConfiguration`**
 
-  Contains the full `AuthenticationConfiguration` object consumed by the Kubernetes API server. For all supported options, see the official Kubernetes documentation:
+  Contains the spec of the `AuthenticationConfiguration` object consumed by the Kubernetes API server. For all supported options, see the official Kubernetes documentation:
   [Authentication configuration from a file](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration).
 
 * **`spec.caSecret`**


### PR DESCRIPTION
This PR removes required apiVersion and kind fields for AuthenticationConfiguration under ClusterAuthentication spec. Now, these fields are automatically propagated and there is no need to configure them.

IMPORTANT:

1. This applies only to KCM v1.10.0 and later. In versions earlier than KCM v1.10.0, both kind and apiVersion must be explicitly specified.
2. This applies only to the spec field of the ClusterAuthentication object. AuthenticationConfiguration object that is used to configure OIDC for the management cluster remains as-is.

Related PR (this change was made in scope of audit policy support for consistency): https://github.com/k0rdent/kcm/pull/2723