### PR TITLE
docs(pi): removed clustergvks field

### DIFF
--- a/docs/admin/access/credentials/cluster-identity-distribution.md
+++ b/docs/admin/access/credentials/cluster-identity-distribution.md
@@ -11,10 +11,10 @@ AccessManagement system (Credentials with `k0rdent.mirantis.com/managed: "true"`
 
 > WARNING:
 > To ensure proper Cluster Identity distribution, make sure the following requirements are met:
-> 
-> 1. The ProviderInterface object is correctly configured. For details, see 
+>
+> 1. The ProviderInterface object is correctly configured. For details, see
 > [ProviderInterface Configuration](#providerinterface-configuration).
-> 
+>
 > 2. When distributing `ClusterIdentity` objects to regional clusters, the provider that defines the corresponding
 > `ClusterIdentity` CRDs must be enabled on the management and on the regional cluster. For example, to distribute
 > an `AWSClusterStaticIdentity` to a regional cluster, the AWS provider must be enabled on both the
@@ -28,7 +28,7 @@ the process step-by-step:
 1. User creates the following `Credential` and identity objects for the Azure provider in `region1` region:
 
     > NOTE:
-    > The name of the `Secret` must follow a specific pattern. See [credential secret](../../../appendix/appendix-providers.md#credential-secret) for details. 
+    > The name of the `Secret` must follow a specific pattern. See [credential secret](../../../appendix/appendix-providers.md#credential-secret) for details.
 
     ```yaml
     apiVersion: k0rdent.mirantis.com/v1beta1
@@ -70,7 +70,7 @@ the process step-by-step:
       clientSecret: "${AZURE_CLIENT_SECRET}"
     type: Opaque
     ```
-   
+
 2. The KCM controller retrieves all the `ProviderInterfaces` from the regional cluster registered with `region1` Region
 and looks for the `AzureClusterIdentity` object definition under `spec.clusterIdentities` of each `ProviderInterface`
 object. If nothing found, the cluster identity distribution will not work.
@@ -101,13 +101,6 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  clusterGVKs:
-    - group: infrastructure.cluster.x-k8s.io
-      version: v1beta1
-      kind: AzureCluster
-    - group: infrastructure.cluster.x-k8s.io
-      version: v1alpha1
-      kind: AzureASOManagedCluster
   clusterIdentities:
     - group: infrastructure.cluster.x-k8s.io
       version: v1beta1
@@ -137,6 +130,3 @@ a `Secret` with the name defined under `spec.clientSecret.name` and the namespac
 > Cluster Identity distribution will not work if the ProviderInterface for a particular provider does not exist or
 > does not have `spec.clusterIdentities` field defined. The KCM controller will not fail, but it will not create any cluster
 > identity resources automatically. You will have to create it manually.
-
-
-

--- a/docs/reference/provider-interface.md
+++ b/docs/reference/provider-interface.md
@@ -20,6 +20,9 @@ spec:
 
 ### `.spec.clusterGVKs`
 
+> WARNING:
+> Removed in {{{ docsVersionInfo.k0rdentName }}} `v1.11.0`.
+
 List of Group-Version-Kind (GVK) tuples identifying the cluster resource kinds this provider manages. Used by {{{ docsVersionInfo.k0rdentName }}} to locate infrastructure cluster objects for a given `ClusterDeployment`.
 
 ```yaml
@@ -34,6 +37,7 @@ spec:
 ```
 
 **Fields per entry:**
+
 - `group` (string): API group
 - `version` (string): API version
 - `kind` (string): Resource kind
@@ -60,12 +64,14 @@ spec:
 ```
 
 **`ClusterIdentity` fields:**
+
 - `group` (string): API group of the identity object
 - `version` (string): API version of the identity object
 - `kind` (string): Kind of the identity object
 - `references[]`: List of objects transitively referenced by this identity (see below)
 
 **`ClusterIdentityReference` fields:**
+
 - `group` (string): API group of the referenced object
 - `version` (string): API version of the referenced object
 - `kind` (string): Kind of the referenced object


### PR DESCRIPTION
Refs: k0rdent/kcm#2906

‼️ WHAT TO DO WITH THE PR ‼️
1. The docs are related to the **`next` version** of the k0rdent KCM (`1.11.0`)
2. The docs **must be copied** to the **k0rdent Enterprise** docs accordingly, BUT **only** for the version which is based upon **open source `1.11.0`**