### PR TITLE
docs: update vsphere hosted cluster lb IP configuration

### DIFF
--- a/docs/admin/hosted-control-plane/hcp-vmware.md
+++ b/docs/admin/hosted-control-plane/hcp-vmware.md
@@ -53,9 +53,27 @@ Follow these steps to set up a k0smotron-hosted control plane on vSphere.
         vmTemplate: "/DC/vm/template"
         network: "/DC/network/Net"
         k0smotron:
-          service:
-            annotations:
-              kube-vip.io/loadbalancerIPs: "172.16.0.10"
+          patches:
+          - patch:
+              content: |
+                metadata:
+                  annotations:
+                    kube-vip.io/loadbalancerIPs: "172.16.0.10"
+              type: merge
+            target:
+              component: control-plane
+              kind: Service
     ```
+
+    > NOTE:
+    > For `vsphere-hosted-cp` cluster template versions earlier than `1.0.40`, add the legacy annotation-based configuration
+    > instead of the `k0smotron.patches` section. For example:
+    >
+    > ```yaml
+    > k0smotron:
+    >   service:
+    >     annotations:
+    >       kube-vip.io/loadbalancerIPs: "172.16.0.10"
+    > ```
 
 For more information on these parameters, see the [Template reference for vsphere](../../reference/template/template-vsphere.md).


### PR DESCRIPTION
Applies to:
* k0rdent/kcm: v1.11.0+ (starting with vsphere-hosted-cp cluster template v1.0.40)
* k0rdent Enterprise: next release based on k0rdent/kcm v1.11.0+

Relates to https://github.com/k0rdent/kcm/issues/2953