### PR TITLE
OPSEC fix to insert placeholders for account id v1.6.0

### DIFF
--- a/docs/admin/backup/prepare-backups.md
+++ b/docs/admin/backup/prepare-backups.md
@@ -97,8 +97,13 @@ Before you create a manual one-off or scheduled backup, review the steps below a
       > NOTE:
       > If you're using EKS, the "user" is actually a role. If you get an error such as...
       >
+<<<<<<< HEAD
       > ```text
       > AccessDenied: User: arn:aws:sts::026090528175:assumed-role/eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A/i-0f7dad2d91447f173 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::nick-chase-backup-bucket" because no identity-based policy allows the s3:ListBucket action
+=======
+      > ```console { .no-copy }
+      > AccessDenied: User: arn:aws:sts::FAKE_ARN_123:assumed-role/eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A/i-0f7dad2d91447f173 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::nick-chase-backup-bucket" because no identity-based policy allows the s3:ListBucket action
+>>>>>>> c09115da (OPSEC fix to insert placeholders for account id)
       > ```
       >
       > ...you can extract the role from the message (in this example, it's the assumed-role) and create the policy. For example:

--- a/docs/admin/backup/prepare-backups.md
+++ b/docs/admin/backup/prepare-backups.md
@@ -97,13 +97,8 @@ Before you create a manual one-off or scheduled backup, review the steps below a
       > NOTE:
       > If you're using EKS, the "user" is actually a role. If you get an error such as...
       >
-<<<<<<< HEAD
-      > ```text
-      > AccessDenied: User: arn:aws:sts::026090528175:assumed-role/eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A/i-0f7dad2d91447f173 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::nick-chase-backup-bucket" because no identity-based policy allows the s3:ListBucket action
-=======
       > ```console { .no-copy }
       > AccessDenied: User: arn:aws:sts::FAKE_ARN_123:assumed-role/eksctl-JohnDoeEKSK0rdentMgmtClus-NodeInstanceRole-j0olMRJHrM0A/i-0f7dad2d91447f173 is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::nick-chase-backup-bucket" because no identity-based policy allows the s3:ListBucket action
->>>>>>> c09115da (OPSEC fix to insert placeholders for account id)
       > ```
       >
       > ...you can extract the role from the message (in this example, it's the assumed-role) and create the policy. For example:

--- a/docs/admin/installation/create-mgmt-clusters/mgmt-create-eks-multi.md
+++ b/docs/admin/installation/create-mgmt-clusters/mgmt-create-eks-multi.md
@@ -67,9 +67,9 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     ```
     ```console { .no-copy }
     2025-03-05 22:57:15 [ℹ]  will use version 1.31 for new nodegroup(s) based on control plane version
-    2025-03-05 22:57:18 [ℹ]  nodegroup "nickchasek0rdentcontroller-group" will use "" [AmazonLinux2/1.31]
-    2025-03-05 22:57:19 [ℹ]  1 nodegroup (nickchasek0rdentcontroller-group) was included (based on the include/exclude rules)
-    2025-03-05 22:57:19 [ℹ]  will create a CloudFormation stack for each of 1 managed nodegroups in cluster "NickChasek0rdentControlCluster"
+    2025-03-05 22:57:18 [ℹ]  nodegroup "JohnDoek0rdentcontroller-group" will use "" [AmazonLinux2/1.31]
+    2025-03-05 22:57:19 [ℹ]  1 nodegroup (JohnDoek0rdentcontroller-group) was included (based on the include/exclude rules)
+    2025-03-05 22:57:19 [ℹ]  will create a CloudFormation stack for each of 1 managed nodegroups in cluster "JohnDoek0rdentControlCluster"
     ...
     2025-03-05 23:00:27 [ℹ]  all nodegroups have up-to-date cloudformation templates
     ```
@@ -97,7 +97,7 @@ Follow these steps to install and prepare an [Amazon EKS](https://ca-central-1.c
     aws eks update-kubeconfig --region <YOUR_AWS_REGION> --name <CLUSTER_NAME>
     ```
     ```bash
-    Updated context arn:aws:eks:ca-central-1:026090528175:cluster/NickChasek0rdentControlCluster in /home/nick/.kube/config
+    Updated context arn:aws:eks:ca-central-1:FAKE_ARN_123:cluster/JohnDoek0rdentControlCluster in /home/nick/.kube/config
     ```
 
 1. Taint controllers


### PR DESCRIPTION
(cherry picked from commit c09115da6ff030c32b56e6138fab2bbfdc3a0be4)