### PR TITLE
docs(troubleshooting): document patch errors

### DIFF
--- a/docs/appendix/appendix-extend-mgmt.md
+++ b/docs/appendix/appendix-extend-mgmt.md
@@ -375,6 +375,11 @@ cluster. To use it, you must create an image pull secret in a `dockerconfigjson`
 format following the [standard
 procedure](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
+> NOTE:
+> If the `Management` object also defines custom Projectsveltos agent or drift detection patches, use the structured
+> patch format consistently. Mixing legacy bare patches with KCM-generated image pull secret patches can cause
+> [Sveltos PatchTransformer errors](../troubleshooting/known-issues-sveltos-patch-formats.md).
+
 After the secret has been created, you can reference it by name in the helm chart
 values on:
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-There are some situations in which you will need to take extra care to make sure 
+There are some situations in which you will need to take extra care to make sure
 things run smoothly.
 
 - [Inspecting k0rdent events](events.md)
@@ -11,3 +11,4 @@ things run smoothly.
 - [Remote](known-issues-remote.md)
 - [Custom CA Certificates](known-issues-custom-ca.md)
 - [ClusterCtl Issues](known-issues-clusterctl.md)
+- [Sveltos PatchTransformer Errors](known-issues-sveltos-patch-formats.md)

--- a/docs/troubleshooting/known-issues-sveltos-patch-formats.md
+++ b/docs/troubleshooting/known-issues-sveltos-patch-formats.md
@@ -12,7 +12,7 @@ patch: |-
 `: unable to parse SM or JSON patch
 ```
 
-This issue occurs when one of the following Projectsveltos patch ConfigMaps contains both legacy bare patches and
+This issue occurs when one of the following Projectsveltos patch `ConfigMaps` contains both legacy bare patches and
 structured Sveltos `Patch` documents:
 
 - `sveltos-agent-config`
@@ -41,25 +41,25 @@ data:
         - name: registry-pull-secret
 ```
 
-Projectsveltos first attempts to parse all entries in a ConfigMap as structured patches. If any entry is a legacy bare
+Projectsveltos first attempts to parse all entries in a `ConfigMap` as structured patches. If any entry is a legacy bare
 patch, it falls back to interpreting all entries as legacy patches. The structured `image-patch` is then passed to
-kustomize without removing its inner `patch` field, resulting in the duplicate `patch: |-` shown in the error.
+`kustomize` without removing its inner `patch` field, resulting in the duplicate `patch: |-` shown in the error.
 
 ## Verify the Issue
 
-Inspect both ConfigMaps:
+Inspect both `ConfigMaps`:
 
 ```bash
 kubectl -n projectsveltos get configmap \
   sveltos-agent-config drift-detection-config -o yaml
 ```
 
-The issue is present if the same ConfigMap contains a bare patch that starts with `apiVersion`, `{`, or `- op`, and a
+The issue is present if the same `ConfigMap` contains a bare patch that starts with `apiVersion`, `{`, or `- op`, and a
 structured patch that starts with `patch:`.
 
 ## Workaround
 
-Use the structured Sveltos patch format for every custom entry in both ConfigMaps. The following minimal
+Use the structured Sveltos patch format for every custom entry in both `ConfigMaps`. The following minimal
 `Management` fragment configures structured scheduling patches that can coexist with the KCM-generated image pull
 secret patch:
 
@@ -109,5 +109,5 @@ spec:
                   name: drift-detection-manager
 ```
 
-Apply the updated `Management` object, then verify that every entry in both ConfigMaps begins with `patch:`. Existing
+Apply the updated `Management` object, then verify that every entry in both `ConfigMaps` begins with `patch:`. Existing
 custom patch bodies, including tolerations and probes, can remain unchanged inside the inner `patch: |-` block.

--- a/docs/troubleshooting/known-issues-sveltos-patch-formats.md
+++ b/docs/troubleshooting/known-issues-sveltos-patch-formats.md
@@ -1,0 +1,113 @@
+# Sveltos-Managed Services Fail with PatchTransformer Errors
+
+When an authenticated image registry and custom Projectsveltos patches are configured together, Sveltos-managed
+services might fail with an error similar to the following:
+
+```text
+trouble configuring builtin PatchTransformer with config: `
+patch: |-
+  patch: |-
+    - op: add
+      path: /spec/template/spec/imagePullSecrets
+`: unable to parse SM or JSON patch
+```
+
+This issue occurs when one of the following Projectsveltos patch ConfigMaps contains both legacy bare patches and
+structured Sveltos `Patch` documents:
+
+- `sveltos-agent-config`
+- `drift-detection-config`
+
+For example, custom values in the `Management` object might add a legacy strategic merge patch:
+
+```yaml
+data:
+  scheduling-patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: sveltos-agent-manager
+```
+
+At the same time, setting `controller.imagePullSecret` causes KCM to add a structured patch:
+
+```yaml
+data:
+  image-patch: |-
+    patch: |-
+      - op: add
+        path: /spec/template/spec/imagePullSecrets
+        value:
+        - name: registry-pull-secret
+```
+
+Projectsveltos first attempts to parse all entries in a ConfigMap as structured patches. If any entry is a legacy bare
+patch, it falls back to interpreting all entries as legacy patches. The structured `image-patch` is then passed to
+kustomize without removing its inner `patch` field, resulting in the duplicate `patch: |-` shown in the error.
+
+## Verify the Issue
+
+Inspect both ConfigMaps:
+
+```bash
+kubectl -n projectsveltos get configmap \
+  sveltos-agent-config drift-detection-config -o yaml
+```
+
+The issue is present if the same ConfigMap contains a bare patch that starts with `apiVersion`, `{`, or `- op`, and a
+structured patch that starts with `patch:`.
+
+## Workaround
+
+Use the structured Sveltos patch format for every custom entry in both ConfigMaps. The following minimal
+`Management` fragment configures structured scheduling patches that can coexist with the KCM-generated image pull
+secret patch:
+
+```yaml
+spec:
+  providers:
+  - name: projectsveltos
+    config:
+      projectsveltos:
+        classifierManager:
+          agentPatchConfigMap:
+            data:
+              scheduling-patch: |-
+                patch: |-
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: sveltos-agent-manager
+                  spec:
+                    template:
+                      spec:
+                        nodeSelector:
+                          kubernetes.io/os: linux
+                target:
+                  group: apps
+                  version: v1
+                  kind: Deployment
+                  name: sveltos-agent-manager
+        addonController:
+          driftDetectionManagerPatchConfigMap:
+            data:
+              scheduling-patch: |-
+                patch: |-
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: drift-detection-manager
+                  spec:
+                    template:
+                      spec:
+                        nodeSelector:
+                          kubernetes.io/os: linux
+                target:
+                  group: apps
+                  version: v1
+                  kind: Deployment
+                  name: drift-detection-manager
+```
+
+Apply the updated `Management` object, then verify that every entry in both ConfigMaps begins with `patch:`. Existing
+custom patch bodies, including tolerations and probes, can remain unchanged inside the inner `patch: |-` block.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,6 +290,7 @@ nav:
     - KubeVirt: troubleshooting/known-issues-kubevirt.md
     - Custom CA Certificates: troubleshooting/known-issues-custom-ca.md
     - Clusterctl Issues: troubleshooting/known-issues-clusterctl.md
+    - Sveltos PatchTransformer Errors: troubleshooting/known-issues-sveltos-patch-formats.md
   - Frequently Asked Questions: faq/index.md
   - Appendix:
     - Overview: appendix/index.md


### PR DESCRIPTION
Valid for KCM versions `v1.9.0`, `v1.10.0`, `v1.11.0`.

Must be transmitted to the k0rdent-enterprise docs, and target the version(s) based on either of the KCM versions above.

Ref: k0rdent/kcm#2993